### PR TITLE
chore: automate wsl first-run setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,15 @@ If Git cannot be installed (for example, on tightly managed devices), download t
   powershell -ExecutionPolicy Bypass -File .\scripts\windows\setup.ps1 [-DockerInstallerPath C:\path\to\DockerDesktopInstaller.exe]
   ```
 
-  Launches WSL2 (if needed), sets the default distro, provisions Docker Desktop with WSL integration, clones this repository into Linux, and invokes `./scripts/setup-all.sh`. On brand-new installations it seeds the default Linux user automatically, so no interactive username/password prompts block the run. The helper is idempotent: re-running the command resumes from the recorded checkpoints in `tmp\setup-all.state`, fast-forwards the Git checkout, and skips work that already succeeded. Use `-RepoSlug your-user/ai-dev-platform` or `-Branch feature` to target a fork/branch. Provide `-DockerInstallerPath` or set `DOCKER_DESKTOP_INSTALLER` when operating in offline or proxy-restricted environments.
+  Launches WSL2 (if needed), sets the default distro, provisions Docker Desktop with WSL integration, clones this repository into Linux, and invokes `./scripts/setup-all.sh`. On brand-new installations it seeds the default Linux user automatically, so the run proceeds end-to-end without interactive pauses. Re-running the helper is safe: it resumes from checkpoints in `tmp\setup-all.state`, fast-forwards the Git checkout, and skips work that already succeeded. Use `-RepoSlug your-user/ai-dev-platform` or `-Branch feature` to target a fork/branch. Provide `-DockerInstallerPath` or set `DOCKER_DESKTOP_INSTALLER` when operating in offline or proxy-restricted environments.
 
 - **Already inside WSL (optional manual run)**
 
   ```bash
-  ./scripts/setup-all.sh
+  SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state" ./scripts/setup-all.sh
   ```
 
-  Run this from the repository root inside WSL if you prefer to execute the consolidated setup manually. The wrapper installs OS-level packages with `apt`, ensures Node.js/pnpm/gh/gcloud/terraform, validates Docker availability (via Docker Desktop integration), runs onboarding, infrastructure bootstrap, repository hardening, and verifies the workspace (`docker info`, `pnpm lint`, `pnpm type-check`, `pnpm --filter @ai-dev-platform/web test`). Each stage records its completion, so rerunning `./scripts/setup-all.sh` is safe: it reuses prior results, retries only the failed step, and leaves a summary in `tmp/setup-all.state`. Set `RESET_SETUP_STATE=1 ./scripts/setup-all.sh` to force a full rerun. Additional knobs include `SKIP_POST_CHECKS=1` to skip verification, `POST_CHECK_MAX_RETRIES=5` (for example) to allow extra recovery attempts, `DOCKER_DESKTOP_INSTALLER` for offline Docker Desktop installs, and log capture under `tmp/postcheck-*.log`.
+  Run this from the repository root inside WSL if you prefer to execute the consolidated setup manually. The wrapper installs OS-level packages with `apt`, ensures Node.js/pnpm/gh/gcloud/terraform, validates Docker availability (via Docker Desktop integration), runs onboarding, infrastructure bootstrap, repository hardening, and verifies the workspace (`docker info`, `pnpm lint`, `pnpm type-check`, `pnpm --filter @ai-dev-platform/web test`). Each stage records its completion, so rerunning `./scripts/setup-all.sh` is safe: it reuses prior results, retries only the failed step, and writes checkpoints to `~/.cache/ai-dev-platform/setup-state`. Set `RESET_SETUP_STATE=1 ./scripts/setup-all.sh` to force a full rerun. Additional knobs include `SKIP_POST_CHECKS=1` to skip verification, `POST_CHECK_MAX_RETRIES=5` (for example) to allow extra recovery attempts, `DOCKER_DESKTOP_INSTALLER` for offline Docker Desktop installs, and log capture under `tmp/postcheck-*.log`.
 
 ### Manual prerequisites (fallback)
 

--- a/scripts/setup-all.sh
+++ b/scripts/setup-all.sh
@@ -11,9 +11,18 @@ ONBOARD_SCRIPT="$ROOT_DIR/scripts/onboard.sh"
 BOOTSTRAP_SCRIPT="$ROOT_DIR/scripts/bootstrap-infra.sh"
 HARDENING_SCRIPT="$ROOT_DIR/scripts/github-hardening.sh"
 
-STATE_DIR="$ROOT_DIR/tmp"
+STATE_DIR="${SETUP_STATE_DIR:-$ROOT_DIR/tmp}"
+STATE_DIR="${STATE_DIR%/}"
 STATE_FILE="$STATE_DIR/setup-all.state"
 declare -A STEP_STATE=()
+
+ensure_state_dir() {
+  if [[ -n "$STATE_DIR" && ! -d "$STATE_DIR" ]]; then
+    mkdir -p "$STATE_DIR"
+  fi
+}
+
+ensure_state_dir
 
 log() {
   printf '\n[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1"

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -382,7 +382,15 @@ function Get-WslEnvPrefix {
 function Run-SetupAll {
     Write-Section "Running ./scripts/setup-all.sh"
     $envPrefix = Get-WslEnvPrefix
-    $command = if ($envPrefix) { "$envPrefix; cd \$HOME/ai-dev-platform; ./scripts/setup-all.sh" } else { "cd \$HOME/ai-dev-platform; ./scripts/setup-all.sh" }
+    $commands = @()
+    if ($envPrefix) {
+        $commands += $envPrefix
+    }
+    $commands += 'export SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"'
+    $commands += 'mkdir -p "${SETUP_STATE_DIR%/*}"'
+    $commands += 'cd $HOME/ai-dev-platform'
+    $commands += './scripts/setup-all.sh'
+    $command = ($commands -join '; ')
     $result = Invoke-Wsl -Command $command
     if ($result.ExitCode -eq 0) {
         return
@@ -398,8 +406,13 @@ function Prompt-OptionalToken {
         [string]$EnvName,
         [string]$PromptMessage
     )
+<<<<<<< Updated upstream
     $current = [Environment]::GetEnvironmentVariable($EnvName, "Process")
     if (-not [string]::IsNullOrEmpty($current)) {
+=======
+    $current = [Environment]::GetEnvironmentVariable($EnvName, 'Process')
+    if (-not [string]::IsNullOrWhiteSpace($current)) {
+>>>>>>> Stashed changes
         return $false
     }
     $secure = Read-Host "$PromptMessage (press Enter to skip)" -AsSecureString
@@ -413,7 +426,11 @@ function Prompt-OptionalToken {
         [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
     }
     if ($value) {
+<<<<<<< Updated upstream
         [Environment]::SetEnvironmentVariable($EnvName, $value, "Process")
+=======
+        [Environment]::SetEnvironmentVariable($EnvName, $value, 'Process')
+>>>>>>> Stashed changes
         return $true
     }
     return $false


### PR DESCRIPTION
## Summary
- provision a default WSL user automatically so setup.ps1 runs without prompts
- move setup-all state into a per-user cache directory and document the env var for manual runs
- clarify README instructions and keep setup idempotent across reruns