### PR TITLE
fix: guard network warning interpolation

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -224,7 +224,7 @@ function Test-NetworkConnectivity {
                 Invoke-WebRequest -Uri "https://$host" -Method Head -TimeoutSec 10 -UseBasicParsing | Out-Null
             }
         } catch {
-            Write-Warning "Unable to reach $host:$Port. Ensure firewalls or proxies allow outbound HTTPS. Error: $($_.Exception.Message)"
+            Write-Warning ("Unable to reach {0}:{1}. Ensure firewalls or proxies allow outbound HTTPS. Error: {2}" -f $host, $Port, $_.Exception.Message)
             $failures += $host
         }
     }


### PR DESCRIPTION
## Summary
- render the Test-NetworkConnectivity warning message with format placeholders to avoid PowerShell variable parsing errors

## Testing
- lint-staged (auto via commit hook)
