### PR TITLE
fix: normalize wsl home before cloning

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -400,6 +400,10 @@ function Ensure-DockerDesktop {
 function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
     $cloneScript = @"
+user_home=\$(getent passwd \$(whoami) | cut -d: -f6)
+if [ -n \"\$user_home\" ]; then
+  export HOME=\"\$user_home\"
+fi
 if [ ! -d \$HOME/ai-dev-platform/.git ]; then
   git clone https://github.com/$RepoSlug.git \$HOME/ai-dev-platform
 fi


### PR DESCRIPTION
## Summary
- compute the Linux home directory via `getent passwd` before cloning so `$HOME` never resolves to a Windows path
- keeps copy/paste commands working even when environment variables leak from Windows into the WSL context

## Testing
- lint-staged (auto via commit hook)
