### PR TITLE
fix: normalize wsl home before cloning

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -400,6 +400,10 @@ function Ensure-DockerDesktop {
 function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
     $cloneScript = @"
+user_home=\$(getent passwd \$(whoami) | cut -d: -f6)
+if [ -n \"\$user_home\" ]; then
+  export HOME=\"\$user_home\"
+fi
 if [ ! -d \$HOME/ai-dev-platform/.git ]; then
   git clone https://github.com/$RepoSlug.git \$HOME/ai-dev-platform
 fi


### PR DESCRIPTION
## Summary
- normalize $HOME to the Linux home directory before cloning to avoid Windows paths
- treat Docker Desktop settings.json as a PSCustomObject so property checks work on Windows PowerShell

## Testing
- lint-staged (auto)
