### PR TITLE
fix: run clone script with literal shell expansion

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -420,19 +420,19 @@ function Ensure-DockerDesktop {
 
 function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
-    $cloneScript = @"
-user_home=\$(getent passwd \$(whoami) | cut -d: -f6)
-if [ -n \"\$user_home\" ]; then
-  export HOME=\"\$user_home\"
+    $cloneScript = @'
+user_home=$(getent passwd $(whoami) | cut -d: -f6)
+if [ -n "$user_home" ]; then
+  export HOME="$user_home"
 fi
-if [ ! -d \$HOME/ai-dev-platform/.git ]; then
-  git clone https://github.com/$RepoSlug.git \$HOME/ai-dev-platform
+if [ ! -d "$HOME/ai-dev-platform/.git" ]; then
+  git clone https://github.com/$RepoSlug.git "$HOME/ai-dev-platform"
 fi
-cd \$HOME/ai-dev-platform
+cd "$HOME/ai-dev-platform"
 git fetch origin
 git checkout $Branch
 git pull --ff-only origin $Branch || true
-"@
+'@
     $result = Invoke-Wsl -Command $cloneScript
     if ($result.ExitCode -ne 0) {
         throw "Failed to clone or update repository inside WSL (exit $($result.ExitCode))."


### PR DESCRIPTION
## Summary
- switch the repo clone script to a single-quoted here-string so PowerShell does not pre-evaluate `$(...)`
- keeps the home directory normalisation while ensuring `getent` and other shell commands execute inside WSL

## Testing
- lint-staged (auto via commit hook)
