### PR TITLE
fix: silence nativecommanderror from wsl output

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -139,8 +139,11 @@ function Invoke-Wsl {
         $args += @("-u", "root")
     }
     $args += @("--", "bash", "-lc", $prefix)
+    $previousErrorAction = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
     $buffer = & wsl.exe @args 2>&1
     $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = $previousErrorAction
     if ($buffer) {
         $buffer | ForEach-Object { Write-Host $_ }
     }


### PR DESCRIPTION
## Summary
- wrap Invoke-Wsl with a temporary ErrorActionPreference to prevent NativeCommandError when git prints to stderr
- keeps WSL command output visible while allowing the script to proceed on success

## Testing
- lint-staged (auto via commit hook)
