### PR TITLE
fix: expand repo slug while escaping wsl variables

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -423,19 +423,19 @@ function Ensure-DockerDesktop {
 
 function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
-    $cloneScript = @'
-user_home=$(getent passwd $(whoami) | cut -d: -f6)
-if [ -n "$user_home" ]; then
-  export HOME="$user_home"
+    $cloneScript = @"
+user_home=`$(getent passwd `$(whoami) | cut -d: -f6)
+if [ -n "`$user_home" ]; then
+  export HOME="`$user_home"
 fi
-if [ ! -d "$HOME/ai-dev-platform/.git" ]; then
-  git clone https://github.com/$RepoSlug.git "$HOME/ai-dev-platform"
+if [ ! -d "`$HOME/ai-dev-platform/.git" ]; then
+  git clone https://github.com/$RepoSlug.git "`$HOME/ai-dev-platform"
 fi
-cd "$HOME/ai-dev-platform"
+cd "`$HOME/ai-dev-platform"
 git fetch origin
 git checkout $Branch
 git pull --ff-only origin $Branch || true
-'@
+"@
     $result = Invoke-Wsl -Command $cloneScript
     if ($result.ExitCode -ne 0) {
         throw "Failed to clone or update repository inside WSL (exit $($result.ExitCode))."


### PR DESCRIPTION
## Summary
- use a double-quoted here-string with escaped `$` so WSL variables stay literal while repo slug/branch expand
- restores cloning via `git clone https://github.com/$RepoSlug.git` to the actual repo

## Testing
- lint-staged (auto via commit hook)
