### PR TITLE
fix: default setup state parent when no dirname

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -423,19 +423,19 @@ function Ensure-DockerDesktop {
 
 function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
-    $cloneScript = @'
-user_home=$(getent passwd $(whoami) | cut -d: -f6)
-if [ -n "$user_home" ]; then
-  export HOME="$user_home"
+    $cloneScript = @"
+user_home=`$(getent passwd `$(whoami) | cut -d: -f6)
+if [ -n "`$user_home" ]; then
+  export HOME="`$user_home"
 fi
-if [ ! -d "$HOME/ai-dev-platform/.git" ]; then
-  git clone https://github.com/$RepoSlug.git "$HOME/ai-dev-platform"
+if [ ! -d "`$HOME/ai-dev-platform/.git" ]; then
+  git clone https://github.com/$RepoSlug.git "`$HOME/ai-dev-platform"
 fi
-cd "$HOME/ai-dev-platform"
+cd "`$HOME/ai-dev-platform"
 git fetch origin
 git checkout $Branch
 git pull --ff-only origin $Branch || true
-'@
+"@
     $result = Invoke-Wsl -Command $cloneScript
     if ($result.ExitCode -ne 0) {
         throw "Failed to clone or update repository inside WSL (exit $($result.ExitCode))."

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -466,7 +466,7 @@ function Run-SetupAll {
         $commands += $envPrefix
     }
     $commands += 'export SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"'
-    $commands += 'mkdir -p "${SETUP_STATE_DIR%/*}"'
+    $commands += 'STATE_PARENT="${SETUP_STATE_DIR%/*}"; if [ -z "$STATE_PARENT" ]; then STATE_PARENT="$SETUP_STATE_DIR"; fi; mkdir -p "$STATE_PARENT"'
     $commands += 'cd $HOME/ai-dev-platform'
     $commands += './scripts/setup-all.sh'
     $command = ($commands -join '; ')

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -466,7 +466,7 @@ function Run-SetupAll {
         $commands += $envPrefix
     }
     $commands += 'export SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"'
-    $commands += 'STATE_PARENT="${SETUP_STATE_DIR%/*}"; if [ -z "$STATE_PARENT" ]; then STATE_PARENT="$SETUP_STATE_DIR"; fi; mkdir -p "$STATE_PARENT"'
+    $commands += 'STATE_PARENT="${SETUP_STATE_DIR%/*}"; [ -z "$STATE_PARENT" ] && STATE_PARENT="$HOME/.cache/ai-dev-platform"; mkdir -p "$STATE_PARENT"'
     $commands += 'cd $HOME/ai-dev-platform'
     $commands += './scripts/setup-all.sh'
     $command = ($commands -join '; ')


### PR DESCRIPTION
## Summary
- fall back to `$HOME/.cache/ai-dev-platform` when `${SETUP_STATE_DIR%/*}` results in an empty string
- ensures the per-user cache directory is created before running `./scripts/setup-all.sh`

## Testing
- lint-staged (auto via commit hook)
