### PR TITLE
fix: derive setup state parent with dirname

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -466,7 +466,7 @@ function Run-SetupAll {
         $commands += $envPrefix
     }
     $commands += 'export SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"'
-    $commands += 'STATE_PARENT="${SETUP_STATE_DIR%/*}"; [ -z "$STATE_PARENT" ] && STATE_PARENT="$HOME/.cache/ai-dev-platform"; mkdir -p "$STATE_PARENT"'
+    $commands += 'STATE_PARENT=$(dirname "$SETUP_STATE_DIR"); [ "$STATE_PARENT" = "." ] && STATE_PARENT="$HOME/.cache/ai-dev-platform"; mkdir -p "$STATE_PARENT"'
     $commands += 'cd $HOME/ai-dev-platform'
     $commands += './scripts/setup-all.sh'
     $command = ($commands -join '; ')


### PR DESCRIPTION
## Summary
- compute the parent directory for `SETUP_STATE_DIR` using `dirname` and fall back to `$HOME/.cache/ai-dev-platform`
- avoids the empty-operand `mkdir` failure when `%/*` yields an empty string

## Testing
- lint-staged (auto via commit hook)
