### PR TITLE
fix: guard empty setup state dir before mkdir

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -465,8 +465,8 @@ function Run-SetupAll {
     if ($envPrefix) {
         $commands += $envPrefix
     }
-    $commands += 'export SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"'
-    $commands += 'STATE_PARENT=$(dirname "$SETUP_STATE_DIR"); [ "$STATE_PARENT" = "." ] && STATE_PARENT="$HOME/.cache/ai-dev-platform"; mkdir -p "$STATE_PARENT"'
+    $commands += 'export SETUP_STATE_DIR="${SETUP_STATE_DIR:-$HOME/.cache/ai-dev-platform/setup-state}"'
+    $commands += 'STATE_PARENT="${SETUP_STATE_DIR%/*}"; if [ -z "$STATE_PARENT" ] || [ "$STATE_PARENT" = "$SETUP_STATE_DIR" ]; then STATE_PARENT="$HOME/.cache/ai-dev-platform"; fi; mkdir -p "$STATE_PARENT"'
     $commands += 'cd $HOME/ai-dev-platform'
     $commands += './scripts/setup-all.sh'
     $command = ($commands -join '; ')

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -465,8 +465,12 @@ function Run-SetupAll {
     if ($envPrefix) {
         $commands += $envPrefix
     }
-    $commands += 'export SETUP_STATE_DIR="${SETUP_STATE_DIR:-$HOME/.cache/ai-dev-platform/setup-state}"'
-    $commands += 'STATE_PARENT="${SETUP_STATE_DIR%/*}"; if [ -z "$STATE_PARENT" ] || [ "$STATE_PARENT" = "$SETUP_STATE_DIR" ]; then STATE_PARENT="$HOME/.cache/ai-dev-platform"; fi; mkdir -p "$STATE_PARENT"'
+    $commands += 'SETUP_STATE_DIR="${SETUP_STATE_DIR:-$HOME/.cache/ai-dev-platform/setup-state}"'
+    $commands += 'if [ -z "$SETUP_STATE_DIR" ]; then SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"; fi'
+    $commands += 'STATE_PARENT="$(dirname "$SETUP_STATE_DIR")"'
+    $commands += 'if [ -z "$STATE_PARENT" ] || [ "$STATE_PARENT" = "." ]; then STATE_PARENT="$HOME/.cache/ai-dev-platform"; fi'
+    $commands += 'mkdir -p "$STATE_PARENT"'
+    $commands += 'export SETUP_STATE_DIR'
     $commands += 'cd $HOME/ai-dev-platform'
     $commands += './scripts/setup-all.sh'
     $command = ($commands -join '; ')


### PR DESCRIPTION
## Summary
- default `SETUP_STATE_DIR` to `$HOME/.cache/ai-dev-platform/setup-state` when unset
- compute the parent via parameter expansion and fall back if it matches the original path
- prevents the `mkdir: missing operand` failure when `%/*` yields an empty string

## Testing
- lint-staged (auto via commit hook)
