### PR TITLE
fix: ensure setup state path always has parent and basename

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -465,11 +465,13 @@ function Run-SetupAll {
     if ($envPrefix) {
         $commands += $envPrefix
     }
-    $commands += 'SETUP_STATE_DIR="${SETUP_STATE_DIR:-$HOME/.cache/ai-dev-platform/setup-state}"'
-    $commands += 'if [ -z "$SETUP_STATE_DIR" ]; then SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"; fi'
-    $commands += 'STATE_PARENT="$(dirname "$SETUP_STATE_DIR")"'
-    $commands += 'if [ -z "$STATE_PARENT" ] || [ "$STATE_PARENT" = "." ]; then STATE_PARENT="$HOME/.cache/ai-dev-platform"; fi'
-    $commands += 'mkdir -p "$STATE_PARENT"'
+    $commands += 'if [ -z "${SETUP_STATE_DIR:-}" ]; then SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"; fi'
+    $commands += 'STATE_PARENT="${SETUP_STATE_DIR%/*}"'
+    $commands += 'if [ -z "$STATE_PARENT" ] || [ "$STATE_PARENT" = "$SETUP_STATE_DIR" ]; then STATE_PARENT="$HOME/.cache/ai-dev-platform"; fi'
+    $commands += 'STATE_NAME="$(basename "$SETUP_STATE_DIR")"'
+    $commands += 'if [ -z "$STATE_NAME" ] || [ "$STATE_NAME" = "." ]; then STATE_NAME="setup-state"; fi'
+    $commands += 'SETUP_STATE_DIR="$STATE_PARENT/$STATE_NAME"'
+    $commands += 'mkdir -p "$STATE_PARENT" "$SETUP_STATE_DIR"'
     $commands += 'export SETUP_STATE_DIR'
     $commands += 'cd $HOME/ai-dev-platform'
     $commands += './scripts/setup-all.sh'


### PR DESCRIPTION
## Summary
- set a default `SETUP_STATE_DIR` if unset, compute parent via `${SETUP_STATE_DIR%/*}`, and derive a safe basename
- recreate the full path (`$parent/$basename`) and create both directories before invoking `./scripts/setup-all.sh`
- fixes the lingering `mkdir: missing operand` failure seen on clean machines

## Testing
- lint-staged (auto via commit hook)
