### PR TITLE
fix: trim setup state dir trailing slash before mkdir

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -466,13 +466,15 @@ function Run-SetupAll {
         $commands += $envPrefix
     }
     $commands += 'if [ -z "${SETUP_STATE_DIR:-}" ]; then SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"; fi'
+    $commands += 'trimmed="${SETUP_STATE_DIR%%/}"'
+    $commands += 'if [ -z "$trimmed" ]; then trimmed="$HOME/.cache/ai-dev-platform/setup-state"; fi'
+    $commands += 'SETUP_STATE_DIR="$trimmed"'
     $commands += 'STATE_PARENT="${SETUP_STATE_DIR%/*}"'
+    $commands += 'STATE_NAME="${SETUP_STATE_DIR##*/}"'
     $commands += 'if [ -z "$STATE_PARENT" ] || [ "$STATE_PARENT" = "$SETUP_STATE_DIR" ]; then STATE_PARENT="$HOME/.cache/ai-dev-platform"; fi'
-    $commands += 'STATE_NAME="$(basename "$SETUP_STATE_DIR")"'
     $commands += 'if [ -z "$STATE_NAME" ] || [ "$STATE_NAME" = "." ]; then STATE_NAME="setup-state"; fi'
     $commands += 'SETUP_STATE_DIR="$STATE_PARENT/$STATE_NAME"'
-    $commands += 'mkdir -p "$STATE_PARENT"'
-    $commands += 'mkdir -p "$SETUP_STATE_DIR"'
+    $commands += 'mkdir -p "$STATE_PARENT" "$SETUP_STATE_DIR"'
     $commands += 'export SETUP_STATE_DIR'
     $commands += 'cd $HOME/ai-dev-platform'
     $commands += './scripts/setup-all.sh'


### PR DESCRIPTION
## Summary
- normalize `SETUP_STATE_DIR` by removing trailing slashes and ensuring both parent and basename are non-empty
- create parent and final directories with a single `mkdir -p parent final` call to avoid empty operand errors

## Testing
- lint-staged (auto via commit hook)
