### PR TITLE
fix(infra-bootstrap): skip non-interactive runs

### DIFF
--- a/scripts/bootstrap-infra.sh
+++ b/scripts/bootstrap-infra.sh
@@ -994,6 +994,13 @@ load_state
 
 BOOTSTRAP_COMPLETED="${BOOTSTRAP_COMPLETED:-no}"
 
+if [[ ! -t 0 && "${INFRA_BOOTSTRAP_ASSUME_DEFAULTS:-0}" != "1" ]]; then
+  heading "Infrastructure bootstrap"
+  echo "Skipping interactive infrastructure bootstrap (no TTY detected)."
+  echo "Run scripts/bootstrap-infra.sh from an interactive shell when you are ready to provision cloud resources."
+  exit 0
+fi
+
 if [[ "${BOOTSTRAP_COMPLETED:-}" == "yes" ]]; then
   if ! prompt_yes "Infrastructure bootstrap already completed. Re-run anyway?" "N"; then
     echo "Bootstrap already complete. Nothing to do."

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -141,13 +141,19 @@ function Invoke-Wsl {
     $args += @("--", "bash", "-lc", $prefix)
     $previousErrorAction = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
-    $buffer = & wsl.exe @args 2>&1
+    $outputLines = New-Object System.Collections.Generic.List[string]
+    & wsl.exe @args 2>&1 | ForEach-Object {
+        $line = [string]$_
+        $outputLines.Add($line)
+        Write-Host $line
+    }
     $exitCode = $LASTEXITCODE
     $ErrorActionPreference = $previousErrorAction
-    if ($buffer) {
-        $buffer | ForEach-Object { Write-Host $_ }
+    $consoleOutput = if ($outputLines.Count -gt 0) {
+        ($outputLines -join [Environment]::NewLine).TrimEnd()
+    } else {
+        ""
     }
-    $consoleOutput = ($buffer | Out-String).TrimEnd()
     return [PSCustomObject]@{
         ExitCode = $exitCode
         Output   = $consoleOutput


### PR DESCRIPTION
## Summary
- skip infrastructure bootstrap when no TTY is present to avoid blocking prompts
- instruct contributors to rerun scripts/bootstrap-infra.sh manually from an interactive shell

## Testing
- none (PowerShell unavailable in container).