### PR TITLE
fix(setup): skip repo hardening when gh unauthenticated

### DIFF
--- a/scripts/bootstrap-infra.sh
+++ b/scripts/bootstrap-infra.sh
@@ -994,9 +994,9 @@ load_state
 
 BOOTSTRAP_COMPLETED="${BOOTSTRAP_COMPLETED:-no}"
 
-if [[ ! -t 0 && "${INFRA_BOOTSTRAP_ASSUME_DEFAULTS:-0}" != "1" ]]; then
+if [[ ( ! -t 0 || "${WINDOWS_AUTOMATED_SETUP:-0}" == "1" ) && "${INFRA_BOOTSTRAP_ASSUME_DEFAULTS:-0}" != "1" ]]; then
   heading "Infrastructure bootstrap"
-  echo "Skipping interactive infrastructure bootstrap (no TTY detected)."
+  echo "Skipping interactive infrastructure bootstrap (non-interactive environment detected)."
   echo "Run scripts/bootstrap-infra.sh from an interactive shell when you are ready to provision cloud resources."
   exit 0
 fi

--- a/scripts/github-hardening.sh
+++ b/scripts/github-hardening.sh
@@ -186,10 +186,18 @@ to_json_array() {
 FULL_REPO=""
 
 require_gh() {
-  if ! gh auth status >/dev/null 2>&1; then
-    echo "gh CLI is not authenticated. Run 'gh auth login' with a token that has admin access to ${OWNER}/${REPO}." >&2
-    exit 1
+  if gh auth status >/dev/null 2>&1; then
+    return 0
   fi
+
+  if [[ ( ! -t 0 || "${WINDOWS_AUTOMATED_SETUP:-0}" == "1" || "${SETUP_SKIP_GITHUB_HARDENING:-0}" == "1" ) && "${GITHUB_HARDENING_ASSUME_DEFAULTS:-0}" != "1" ]]; then
+    echo "Skipping GitHub repository hardening: gh CLI is not authenticated."
+    echo "Run './scripts/github-hardening.sh' after completing 'gh auth login' with admin access to ${OWNER}/${REPO}."
+    exit 0
+  fi
+
+  echo "gh CLI is not authenticated. Run 'gh auth login' with a token that has admin access to ${OWNER}/${REPO}." >&2
+  exit 1
 }
 
 enable_security_features() {

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -471,6 +471,7 @@ function Run-SetupAll {
     if ($envPrefix) {
         $commands += $envPrefix
     }
+    $commands += 'export WINDOWS_AUTOMATED_SETUP=1'
     $commands += 'if [ -z "${SETUP_STATE_DIR:-}" ]; then SETUP_STATE_DIR="$HOME/.cache/ai-dev-platform/setup-state"; fi'
     $commands += 'export SETUP_STATE_DIR'
     $commands += 'cd $HOME/ai-dev-platform'


### PR DESCRIPTION
## Summary
- detect automated/non-interactive runs in github-hardening
- skip the repo-hardening step if gh auth is unavailable so Windows bootstrap can finish

## Testing
- ./scripts/setup-all.sh