### PR TITLE
fix(setup): guide users when github hardening is skipped

### DIFF
--- a/scripts/github-hardening.sh
+++ b/scripts/github-hardening.sh
@@ -419,6 +419,11 @@ main() {
   configure_environment "staging" "$STAGING_WAIT_MINUTES" "${STAGING_REVIEWERS[@]}"
   configure_environment "production" "$PRODUCTION_WAIT_MINUTES" "${PRODUCTION_REVIEWERS[@]}"
 
+  local notice_file="$REPO_ROOT/tmp/github-hardening.pending"
+  if [[ -f "$notice_file" ]]; then
+    rm -f "$notice_file"
+  fi
+
   echo "✔ Repository hardening complete for ${FULL_REPO}."
 }
 

--- a/scripts/setup-all.sh
+++ b/scripts/setup-all.sh
@@ -141,6 +141,13 @@ clear_last_failure() {
   fi
 }
 
+clear_step_state() {
+  local key="$1"
+  unset STEP_STATE["done_${key}"]
+  unset STEP_STATE["done_${key}_timestamp"]
+  save_state
+}
+
 print_resume_summary() {
   if [[ -n "${STEP_STATE[last_failure]:-}" ]]; then
     warn "Previous setup attempt failed: ${STEP_STATE[last_failure]}"
@@ -780,6 +787,7 @@ print_pending_guidance() {
     while IFS= read -r line; do
       printf '%s\n' "$line"
     done <"$pending_file"
+    clear_step_state "github_hardening"
   fi
 }
 


### PR DESCRIPTION
## Summary
- leave a reminder file when github hardening is skipped due to missing gh auth
- surface that reminder at the end of setup and reset state so the step reruns later
- remove the reminder after successful hardening

## Testing
- ./scripts/setup-all.sh