### PR TITLE
fix: harden windows bootstrap flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Before you start, make sure you can provide the following:
 
    What the helper does:
    - Enables WSL2 features, installs/initializes Ubuntu, and sets it as default.
-   - Installs **Cursor** via winget (or instructs you to install it manually if winget is unavailable).
+   - Installs **Cursor** via winget (and falls back to downloading the latest Windows installer from GitHub releases if winget cannot find it).
    - Installs/updates Docker Desktop, enables WSL integration, and waits for the daemon.
    - Clones the repository inside WSL and executes `./scripts/setup-all.sh`.
    - Launches `gh auth login --web` inside both Windows and WSL contexts (if needed), refreshes the token scopes (`repo`, `workflow`, `admin:org`), and verifies the signed-in user has admin rights on the repository. The helper relays the OAuth URL to your Windows browser automatically; if it does not open, copy the printed URL manually and paste it into your browser.
@@ -195,7 +195,7 @@ Before you start, make sure you can provide the following:
 - **Replay GitHub hardening:** `./scripts/github-hardening.sh` (the script relaunches `gh auth login --web` until successful).
 - **Provide GitHub admin rights:** the account used during `gh auth login` must have admin permissions on `${OWNER}/${REPO}`; otherwise the hardening step will pause with instructions.
 - **Docker not ready:** On Windows, ensure Docker Desktop is running with WSL integration enabled; rerun the bootstrap helper.
-- **Cursor missing:** Install it manually from <https://cursor.sh/download> and rerun the helper or `./scripts/update-editor-extensions.sh`.
+- **Cursor missing:** Re-run the Windows bootstrap; it now downloads the latest installer from GitHub if winget cannot find it. As a fallback you can install manually from <https://cursor.sh/download> and rerun the helper or `./scripts/update-editor-extensions.sh`.
 
 ### Additional scripts
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -56,7 +56,7 @@
    Repository hardening launches `gh auth login --web` (Windows and WSL), refreshes the token scopes (`repo`, `workflow`, `admin:org`), and confirms the signed-in user has administrator rights on the repository. The helper relays each OAuth link to your Windows browser automatically; if it does not open, copy the printed URL manually. If you cancel or sign in with a non-admin account, rerun `./scripts/github-hardening.sh` later—it will keep prompting until authentication succeeds with an administrator.
 
 5. **Sign into Cursor, Codex, and Claude Code extensions**
-   - Launch Cursor (the Windows bootstrap installs it via winget and offers to open it when setup finishes; macOS/Linux users can download from <https://cursor.sh/>).
+   - Launch Cursor (the Windows bootstrap installs it via winget and falls back to downloading the latest Windows installer from the Cursor GitHub releases if winget cannot locate it).
    - Sign into GitHub inside Cursor.
    - Open the Command Palette and run “Codex: Sign In” followed by “Claude Code: Sign In”.
 


### PR DESCRIPTION
## Summary
- add Cursor installer fallback that downloads the latest release when winget is unavailable or fails
- harden browser relays by installing an open-in-windows shim for gh and gcloud flows
- document the Cursor fallback in README/ONBOARDING and tidy the onboarding list indentation

## Testing
- not run (PowerShell-specific changes)