### PR TITLE
fix: harden Cursor installation fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Before you start, make sure you can provide the following:
 
    What the helper does:
    - Enables WSL2 features, installs/initializes Ubuntu, and sets it as default.
-   - Installs **Cursor** via winget (and falls back to downloading the latest Windows installer from GitHub releases if winget cannot find it).
+   - Installs **Cursor** via winget (and automatically fetches the newest Windows installer from Cursor's GitHub releases—honoring proxy env vars—if winget cannot find or install it).
    - Installs/updates Docker Desktop, enables WSL integration, and waits for the daemon.
    - Clones the repository inside WSL and executes `./scripts/setup-all.sh`.
    - Launches `gh auth login --web` inside both Windows and WSL contexts (if needed), refreshes the token scopes (`repo`, `workflow`, `admin:org`), and verifies the signed-in user has admin rights on the repository. The helper relays the OAuth URL to your Windows browser automatically; if it does not open, copy the printed URL manually and paste it into your browser.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -56,7 +56,7 @@
    Repository hardening launches `gh auth login --web` (Windows and WSL), refreshes the token scopes (`repo`, `workflow`, `admin:org`), and confirms the signed-in user has administrator rights on the repository. The helper relays each OAuth link to your Windows browser automatically; if it does not open, copy the printed URL manually. If you cancel or sign in with a non-admin account, rerun `./scripts/github-hardening.sh` later—it will keep prompting until authentication succeeds with an administrator.
 
 5. **Sign into Cursor, Codex, and Claude Code extensions**
-   - Launch Cursor (the Windows bootstrap installs it via winget and falls back to downloading the latest Windows installer from the Cursor GitHub releases if winget cannot locate it).
+   - Launch Cursor (the Windows bootstrap installs it via winget and, if that fails, fetches the newest Windows installer directly from Cursor's GitHub releases—respecting corporate proxy env vars).
    - Sign into GitHub inside Cursor.
    - Open the Command Palette and run “Codex: Sign In” followed by “Claude Code: Sign In”.
 


### PR DESCRIPTION
## Summary
- detect existing Cursor installs across standard locations and avoid redundant reinstalls
- resolve latest Cursor installer via GitHub API (reusing proxy + token configuration) before falling back to static download
- document the smarter fallback and proxy support in README and onboarding guide

## Testing
- pnpm exec prettier --check README.md docs/ONBOARDING.md