### PR TITLE
chore: ensure workflow guards always run

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,7 +25,6 @@ jobs:
 
   provision-check:
     name: Provision Guard
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.evaluate.outputs.ready }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -25,7 +25,6 @@ jobs:
 
   provision-check:
     name: Provision Guard
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.evaluate.outputs.ready }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,7 +34,6 @@ jobs:
 
   provision-check:
     name: Provision Guard
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.evaluate.outputs.ready }}


### PR DESCRIPTION
## Summary
- let terraform and deploy guard jobs execute on every trigger so the workflow records a skip instead of failing with zero jobs

## Testing
- pnpm exec prettier --check README.md docs/ONBOARDING.md