### PR TITLE
chore: ensure workflow guards always run

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -17,54 +17,88 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  context:
+    name: Context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Deploy production workflow triggered on $GITHUB_REF via $GITHUB_EVENT_NAME"
+
   skip:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Production deploy runs only on main; current ref ${{ github.ref }}."
 
-  provision-check:
-    name: Provision Guard
+  deploy-gate:
+    name: Deploy to Production - Gate
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     outputs:
-      ready: ${{ steps.evaluate.outputs.ready }}
+      should_run: ${{ steps.evaluate.outputs.should_run }}
       reason: ${{ steps.evaluate.outputs.reason }}
     steps:
       - id: evaluate
+        env:
+          PRODUCTION_ENABLED: ${{ vars.PRODUCTION_DEPLOY_ENABLED }}
+          SECRET_IMAGE_REPO: ${{ secrets.PRODUCTION_IMAGE_REPO }}
+          SECRET_REGISTRY_HOST: ${{ secrets.PRODUCTION_ARTIFACT_REGISTRY_HOST }}
+          SECRET_GCP_PROJECT_ID: ${{ secrets.PRODUCTION_GCP_PROJECT_ID }}
+          SECRET_GKE_LOCATION: ${{ secrets.PRODUCTION_GKE_LOCATION }}
+          SECRET_GKE_CLUSTER: ${{ secrets.PRODUCTION_GKE_CLUSTER }}
+          SECRET_WIP: ${{ secrets.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER }}
+          SECRET_WISA: ${{ secrets.PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          SECRET_RUNTIME_GSA: ${{ secrets.PRODUCTION_RUNTIME_GSA_EMAIL }}
         run: |
-          missing=()
-          note() { printf '::notice::%s\n' "$1"; }
+          set -euo pipefail
+          should_run=false
+          reason=""
+
+          if ! { [ "$PRODUCTION_ENABLED" = "true" ] || [ -z "$PRODUCTION_ENABLED" ]; }; then
+            reason="enable vars.PRODUCTION_DEPLOY_ENABLED"
+          fi
+
           check_secret() {
-            local key="$1"
-            local value="$2"
+            local value="$1"
+            local name="$2"
             if [ -z "$value" ]; then
-              missing+=("$key")
+              if [ -n "$reason" ]; then
+                reason+=" "
+              fi
+              reason+="missing_secret:${name}"
             fi
           }
-          check_secret "PRODUCTION_IMAGE_REPO" "${{ secrets.PRODUCTION_IMAGE_REPO }}"
-          check_secret "PRODUCTION_ARTIFACT_REGISTRY_HOST" "${{ secrets.PRODUCTION_ARTIFACT_REGISTRY_HOST }}"
-          check_secret "PRODUCTION_GCP_PROJECT_ID" "${{ secrets.PRODUCTION_GCP_PROJECT_ID }}"
-          check_secret "PRODUCTION_GKE_LOCATION" "${{ secrets.PRODUCTION_GKE_LOCATION }}"
-          check_secret "PRODUCTION_GKE_CLUSTER" "${{ secrets.PRODUCTION_GKE_CLUSTER }}"
-          check_secret "PRODUCTION_WORKLOAD_IDENTITY_PROVIDER" "${{ secrets.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER }}"
-          check_secret "PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT" "${{ secrets.PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}"
-          check_secret "PRODUCTION_RUNTIME_GSA_EMAIL" "${{ secrets.PRODUCTION_RUNTIME_GSA_EMAIL }}"
-          if [ "${#missing[@]}" -gt 0 ]; then
-            reason="Missing secrets: ${missing[*]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "reason=${reason//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            note "Production deploy skipped – ${reason}"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "reason=ready" >> "$GITHUB_OUTPUT"
-            note "Production deploy prerequisites satisfied."
+
+          if [ -z "$reason" ]; then
+            check_secret "$SECRET_IMAGE_REPO" "PRODUCTION_IMAGE_REPO"
+            check_secret "$SECRET_REGISTRY_HOST" "PRODUCTION_ARTIFACT_REGISTRY_HOST"
+            check_secret "$SECRET_GCP_PROJECT_ID" "PRODUCTION_GCP_PROJECT_ID"
+            check_secret "$SECRET_GKE_LOCATION" "PRODUCTION_GKE_LOCATION"
+            check_secret "$SECRET_GKE_CLUSTER" "PRODUCTION_GKE_CLUSTER"
+            check_secret "$SECRET_WIP" "PRODUCTION_WORKLOAD_IDENTITY_PROVIDER"
+            check_secret "$SECRET_WISA" "PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT"
+            check_secret "$SECRET_RUNTIME_GSA" "PRODUCTION_RUNTIME_GSA_EMAIL"
           fi
+
+          if [ -z "$reason" ]; then
+            should_run=true
+            reason="ready"
+          fi
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
+  explain-deploy-skip:
+    name: Deploy to Production (skipped)
+    needs: deploy-gate
+    if: ${{ needs.deploy-gate.outputs.should_run != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Production deploy skipped – ${{ needs.deploy-gate.outputs.reason }}"
 
   deploy:
     name: Deploy to Production
-    needs: provision-check
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.provision-check.outputs.ready == 'true' && (vars.PRODUCTION_DEPLOY_ENABLED == 'true' || vars.PRODUCTION_DEPLOY_ENABLED == '' || vars.PRODUCTION_DEPLOY_ENABLED == null) }}
+    needs: deploy-gate
+    if: ${{ needs.deploy-gate.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     environment: production
     env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,54 +17,88 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  context:
+    name: Context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Deploy staging workflow triggered on $GITHUB_REF via $GITHUB_EVENT_NAME"
+
   skip:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Staging deploy runs only on main; current ref ${{ github.ref }}."
 
-  provision-check:
-    name: Provision Guard
+  deploy-gate:
+    name: Deploy to Staging - Gate
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     outputs:
-      ready: ${{ steps.evaluate.outputs.ready }}
+      should_run: ${{ steps.evaluate.outputs.should_run }}
       reason: ${{ steps.evaluate.outputs.reason }}
     steps:
       - id: evaluate
+        env:
+          STAGING_ENABLED: ${{ vars.STAGING_DEPLOY_ENABLED }}
+          SECRET_IMAGE_REPO: ${{ secrets.STAGING_IMAGE_REPO }}
+          SECRET_REGISTRY_HOST: ${{ secrets.STAGING_ARTIFACT_REGISTRY_HOST }}
+          SECRET_GCP_PROJECT_ID: ${{ secrets.STAGING_GCP_PROJECT_ID }}
+          SECRET_GKE_LOCATION: ${{ secrets.STAGING_GKE_LOCATION }}
+          SECRET_GKE_CLUSTER: ${{ secrets.STAGING_GKE_CLUSTER }}
+          SECRET_WIP: ${{ secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER }}
+          SECRET_WISA: ${{ secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          SECRET_RUNTIME_GSA: ${{ secrets.STAGING_RUNTIME_GSA_EMAIL }}
         run: |
-          missing=()
-          note() { printf '::notice::%s\n' "$1"; }
+          set -euo pipefail
+          should_run=false
+          reason=""
+
+          if ! { [ "$STAGING_ENABLED" = "true" ] || [ -z "$STAGING_ENABLED" ]; }; then
+            reason="enable vars.STAGING_DEPLOY_ENABLED"
+          fi
+
           check_secret() {
-            local key="$1"
-            local value="$2"
+            local value="$1"
+            local name="$2"
             if [ -z "$value" ]; then
-              missing+=("$key")
+              if [ -n "$reason" ]; then
+                reason+=" "
+              fi
+              reason+="missing_secret:${name}"
             fi
           }
-          check_secret "STAGING_IMAGE_REPO" "${{ secrets.STAGING_IMAGE_REPO }}"
-          check_secret "STAGING_ARTIFACT_REGISTRY_HOST" "${{ secrets.STAGING_ARTIFACT_REGISTRY_HOST }}"
-          check_secret "STAGING_GCP_PROJECT_ID" "${{ secrets.STAGING_GCP_PROJECT_ID }}"
-          check_secret "STAGING_GKE_LOCATION" "${{ secrets.STAGING_GKE_LOCATION }}"
-          check_secret "STAGING_GKE_CLUSTER" "${{ secrets.STAGING_GKE_CLUSTER }}"
-          check_secret "STAGING_WORKLOAD_IDENTITY_PROVIDER" "${{ secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER }}"
-          check_secret "STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT" "${{ secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}"
-          check_secret "STAGING_RUNTIME_GSA_EMAIL" "${{ secrets.STAGING_RUNTIME_GSA_EMAIL }}"
-          if [ "${#missing[@]}" -gt 0 ]; then
-            reason="Missing secrets: ${missing[*]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "reason=${reason//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            note "Staging deploy skipped – ${reason}"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "reason=ready" >> "$GITHUB_OUTPUT"
-            note "Staging deploy prerequisites satisfied."
+
+          if [ -z "$reason" ]; then
+            check_secret "$SECRET_IMAGE_REPO" "STAGING_IMAGE_REPO"
+            check_secret "$SECRET_REGISTRY_HOST" "STAGING_ARTIFACT_REGISTRY_HOST"
+            check_secret "$SECRET_GCP_PROJECT_ID" "STAGING_GCP_PROJECT_ID"
+            check_secret "$SECRET_GKE_LOCATION" "STAGING_GKE_LOCATION"
+            check_secret "$SECRET_GKE_CLUSTER" "STAGING_GKE_CLUSTER"
+            check_secret "$SECRET_WIP" "STAGING_WORKLOAD_IDENTITY_PROVIDER"
+            check_secret "$SECRET_WISA" "STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT"
+            check_secret "$SECRET_RUNTIME_GSA" "STAGING_RUNTIME_GSA_EMAIL"
           fi
+
+          if [ -z "$reason" ]; then
+            should_run=true
+            reason="ready"
+          fi
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
+  explain-deploy-skip:
+    name: Deploy to Staging (skipped)
+    needs: deploy-gate
+    if: ${{ needs.deploy-gate.outputs.should_run != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Staging deploy skipped – ${{ needs.deploy-gate.outputs.reason }}"
 
   deploy:
     name: Deploy to Staging
-    needs: provision-check
-    if: ${{ github.ref == 'refs/heads/main' && needs.provision-check.outputs.ready == 'true' && (vars.STAGING_DEPLOY_ENABLED == 'true' || vars.STAGING_DEPLOY_ENABLED == '' || vars.STAGING_DEPLOY_ENABLED == null) }}
+    needs: deploy-gate
+    if: ${{ needs.deploy-gate.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     environment: staging
     env:

--- a/.github/workflows/security-validation-ba.yml
+++ b/.github/workflows/security-validation-ba.yml
@@ -10,50 +10,37 @@ permissions:
   id-token: write
 
 jobs:
+  context:
+    name: Context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Binary Authorization validation triggered on $GITHUB_REF via $GITHUB_EVENT_NAME"
+
   skip:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - run: echo "BA validation runs only on main; current ref ${{ github.ref }}."
 
-  provision-check:
-    name: Provision Guard
+  explain-validation-skip:
+    name: Binary Authorization Validation (skipped)
     runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.evaluate.outputs.ready }}
-      reason: ${{ steps.evaluate.outputs.reason }}
+    if: ${{ secrets.STAGING_GCP_PROJECT_ID == '' || secrets.STAGING_GKE_LOCATION == '' || secrets.STAGING_GKE_CLUSTER == '' || secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER == '' || secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT == '' }}
     steps:
-      - id: evaluate
+      - name: Summarize missing prerequisites
         run: |
           missing=()
-          note() { printf '::notice::%s\n' "$1"; }
-          check_secret() {
-            local key="$1"
-            local value="$2"
-            if [ -z "$value" ]; then
-              missing+=("$key")
-            fi
-          }
-          check_secret "STAGING_GCP_PROJECT_ID" "${{ secrets.STAGING_GCP_PROJECT_ID }}"
-          check_secret "STAGING_GKE_LOCATION" "${{ secrets.STAGING_GKE_LOCATION }}"
-          check_secret "STAGING_GKE_CLUSTER" "${{ secrets.STAGING_GKE_CLUSTER }}"
-          check_secret "STAGING_WORKLOAD_IDENTITY_PROVIDER" "${{ secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER }}"
-          check_secret "STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT" "${{ secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}"
-          if [ "${#missing[@]}" -gt 0 ]; then
-            reason="Missing secrets: ${missing[*]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "reason=${reason//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            note "Binary Authorization validation skipped – ${reason}"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "reason=ready" >> "$GITHUB_OUTPUT"
-            note "Binary Authorization validation prerequisites satisfied."
-          fi
+          add_missing() { missing+=("$1"); }
+          [ -n "${{ secrets.STAGING_GCP_PROJECT_ID }}" ] || add_missing "STAGING_GCP_PROJECT_ID"
+          [ -n "${{ secrets.STAGING_GKE_LOCATION }}" ] || add_missing "STAGING_GKE_LOCATION"
+          [ -n "${{ secrets.STAGING_GKE_CLUSTER }}" ] || add_missing "STAGING_GKE_CLUSTER"
+          [ -n "${{ secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER }}" ] || add_missing "STAGING_WORKLOAD_IDENTITY_PROVIDER"
+          [ -n "${{ secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}" ] || add_missing "STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT"
+          echo "::notice::Binary Authorization validation skipped. Missing secrets: ${missing[*]}."
 
   validate-binary-authorization:
     name: Validate Binary Authorization Enforcement
-    needs: provision-check
-    if: ${{ needs.provision-check.outputs.ready == 'true' }}
+    if: ${{ secrets.STAGING_GCP_PROJECT_ID != '' && secrets.STAGING_GKE_LOCATION != '' && secrets.STAGING_GKE_CLUSTER != '' && secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT != '' }}
     runs-on: ubuntu-latest
     environment: staging
     env:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,48 +26,17 @@ env:
   TERRAFORM_VERSION: '1.8.5'
 
 jobs:
+  context:
+    name: Context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Terraform workflow triggered on $GITHUB_REF via $GITHUB_EVENT_NAME"
+
   skip:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Terraform applies run only on main; current ref ${{ github.ref }}."
-
-  provision-check:
-    name: Provision Guard
-    if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.evaluate.outputs.ready }}
-      reason: ${{ steps.evaluate.outputs.reason }}
-    steps:
-      - id: evaluate
-        run: |
-          missing=()
-          note() { printf '::notice::%s\n' "$1"; }
-          check_secret() {
-            local key="$1"
-            local value="$2"
-            if [ -z "$value" ]; then
-              missing+=("$key")
-            fi
-          }
-          check_secret "TERRAFORM_SERVICE_ACCOUNT" "${{ secrets.TERRAFORM_SERVICE_ACCOUNT }}"
-          check_secret "WORKLOAD_IDENTITY_PROVIDER" "${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}"
-          check_secret "GCP_PROJECT_ID" "${{ secrets.GCP_PROJECT_ID }}"
-          check_secret "GCP_REGION" "${{ secrets.GCP_REGION }}"
-          check_secret "RUNTIME_KSA_NAMESPACE" "${{ secrets.RUNTIME_KSA_NAMESPACE }}"
-          check_secret "RUNTIME_KSA_NAME" "${{ secrets.RUNTIME_KSA_NAME }}"
-          check_secret "BA_ATTESTORS" "${{ secrets.BA_ATTESTORS }}"
-          if [ "${#missing[@]}" -gt 0 ]; then
-            reason="Missing secrets: ${missing[*]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "reason=${reason//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            note "Terraform apply skipped – ${reason}"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "reason=ready" >> "$GITHUB_OUTPUT"
-            note "Terraform apply prerequisites satisfied."
-          fi
 
   plan:
     name: Plan (staging)
@@ -167,10 +136,90 @@ jobs:
           echo "Terraform plan failed"
           exit 1
 
+  apply-gate:
+    name: Terraform Apply - Gate
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.evaluate.outputs.should_run }}
+      reason: ${{ steps.evaluate.outputs.reason }}
+      target_env: ${{ steps.evaluate.outputs.target_env }}
+    steps:
+      - id: evaluate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          STAGING_ENABLED: ${{ vars.STAGING_INFRA_ENABLED }}
+          PRODUCTION_ENABLED: ${{ vars.PRODUCTION_INFRA_ENABLED }}
+          SECRET_TERRAFORM_SERVICE_ACCOUNT: ${{ secrets.TERRAFORM_SERVICE_ACCOUNT }}
+          SECRET_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          SECRET_GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          SECRET_GCP_REGION: ${{ secrets.GCP_REGION }}
+          SECRET_RUNTIME_KSA_NAMESPACE: ${{ secrets.RUNTIME_KSA_NAMESPACE }}
+          SECRET_RUNTIME_KSA_NAME: ${{ secrets.RUNTIME_KSA_NAME }}
+          SECRET_BA_ATTESTORS: ${{ secrets.BA_ATTESTORS }}
+        run: |
+          set -euo pipefail
+          should_run=false
+          reason=""
+          target=""
+
+          if [ "$EVENT_NAME" != "push" ]; then
+            reason="event_not_push"
+          else
+            if [ "$REF" = "refs/heads/main" ]; then
+              target="staging"
+              if [ "$STAGING_ENABLED" != "true" ]; then
+                reason+=" enable vars.STAGING_INFRA_ENABLED"
+              fi
+            elif [[ "$REF" == refs/tags/v* ]]; then
+              target="production"
+              if [ "$PRODUCTION_ENABLED" != "true" ]; then
+                reason+=" enable vars.PRODUCTION_INFRA_ENABLED"
+              fi
+            else
+              reason="non_deploy_ref"
+            fi
+          fi
+
+          check_secret() {
+            local value="$1"
+            local name="$2"
+            if [ -z "$value" ]; then
+              reason+=" missing_secret:${name}"
+            fi
+          }
+
+          if [ -z "$reason" ]; then
+            check_secret "$SECRET_TERRAFORM_SERVICE_ACCOUNT" "TERRAFORM_SERVICE_ACCOUNT"
+            check_secret "$SECRET_WORKLOAD_IDENTITY_PROVIDER" "WORKLOAD_IDENTITY_PROVIDER"
+            check_secret "$SECRET_GCP_PROJECT_ID" "GCP_PROJECT_ID"
+            check_secret "$SECRET_GCP_REGION" "GCP_REGION"
+            check_secret "$SECRET_RUNTIME_KSA_NAMESPACE" "RUNTIME_KSA_NAMESPACE"
+            check_secret "$SECRET_RUNTIME_KSA_NAME" "RUNTIME_KSA_NAME"
+            check_secret "$SECRET_BA_ATTESTORS" "BA_ATTESTORS"
+          fi
+
+          if [ -z "$reason" ]; then
+            should_run=true
+            reason="ready"
+          fi
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "reason=${reason# }" >> "$GITHUB_OUTPUT"
+          echo "target_env=${target:-none}" >> "$GITHUB_OUTPUT"
+
+  explain-apply-skip:
+    name: Terraform Apply (skipped)
+    needs: apply-gate
+    if: ${{ needs.apply-gate.outputs.should_run != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Terraform apply skipped – ${{ needs.apply-gate.outputs.reason }}"
+
   apply:
     name: Apply
-    needs: provision-check
-    if: ${{ github.event_name == 'push' && needs.provision-check.outputs.ready == 'true' && ((github.ref == 'refs/heads/main' && vars.STAGING_INFRA_ENABLED == 'true') || (startsWith(github.ref, 'refs/tags/v') && vars.PRODUCTION_INFRA_ENABLED == 'true')) }}
+    needs: apply-gate
+    if: ${{ needs.apply-gate.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'staging' || 'production' }}
     concurrency:


### PR DESCRIPTION
## Summary
- convert terraform/deploy workflows to skip gracefully by adding skip jobs and explicit secret/variable guards
- surface skip notices that list missing prerequisites so the pipelines never fail with zero jobs

## Testing
- pnpm exec prettier --check README.md docs/ONBOARDING.md