### PR TITLE
chore: guard infrastructure workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -17,53 +17,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  context:
+    name: Context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Deploy production workflow triggered on $GITHUB_REF via $GITHUB_EVENT_NAME"
+
   skip:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Production deploy runs only on main; current ref ${{ github.ref }}."
 
-  provision-check:
-    name: Provision Guard
+  explain-deploy-skip:
+    name: Deploy to Production (skipped)
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !((vars.PRODUCTION_DEPLOY_ENABLED == 'true' || vars.PRODUCTION_DEPLOY_ENABLED == '' || vars.PRODUCTION_DEPLOY_ENABLED == null) && secrets.PRODUCTION_IMAGE_REPO != '' && secrets.PRODUCTION_ARTIFACT_REGISTRY_HOST != '' && secrets.PRODUCTION_GCP_PROJECT_ID != '' && secrets.PRODUCTION_GKE_LOCATION != '' && secrets.PRODUCTION_GKE_CLUSTER != '' && secrets.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT != '' && secrets.PRODUCTION_RUNTIME_GSA_EMAIL != '') }}
     runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.evaluate.outputs.ready }}
-      reason: ${{ steps.evaluate.outputs.reason }}
     steps:
-      - id: evaluate
+      - name: Summarize missing prerequisites
         run: |
           missing=()
-          note() { printf '::notice::%s\n' "$1"; }
-          check_secret() {
-            local key="$1"
-            local value="$2"
-            if [ -z "$value" ]; then
-              missing+=("$key")
-            fi
-          }
-          check_secret "PRODUCTION_IMAGE_REPO" "${{ secrets.PRODUCTION_IMAGE_REPO }}"
-          check_secret "PRODUCTION_ARTIFACT_REGISTRY_HOST" "${{ secrets.PRODUCTION_ARTIFACT_REGISTRY_HOST }}"
-          check_secret "PRODUCTION_GCP_PROJECT_ID" "${{ secrets.PRODUCTION_GCP_PROJECT_ID }}"
-          check_secret "PRODUCTION_GKE_LOCATION" "${{ secrets.PRODUCTION_GKE_LOCATION }}"
-          check_secret "PRODUCTION_GKE_CLUSTER" "${{ secrets.PRODUCTION_GKE_CLUSTER }}"
-          check_secret "PRODUCTION_WORKLOAD_IDENTITY_PROVIDER" "${{ secrets.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER }}"
-          check_secret "PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT" "${{ secrets.PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}"
-          check_secret "PRODUCTION_RUNTIME_GSA_EMAIL" "${{ secrets.PRODUCTION_RUNTIME_GSA_EMAIL }}"
-          if [ "${#missing[@]}" -gt 0 ]; then
-            reason="Missing secrets: ${missing[*]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "reason=${reason//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            note "Production deploy skipped – ${reason}"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "reason=ready" >> "$GITHUB_OUTPUT"
-            note "Production deploy prerequisites satisfied."
+          add_missing() { missing+=("$1"); }
+          [ -n "${{ secrets.PRODUCTION_IMAGE_REPO }}" ] || add_missing "PRODUCTION_IMAGE_REPO"
+          [ -n "${{ secrets.PRODUCTION_ARTIFACT_REGISTRY_HOST }}" ] || add_missing "PRODUCTION_ARTIFACT_REGISTRY_HOST"
+          [ -n "${{ secrets.PRODUCTION_GCP_PROJECT_ID }}" ] || add_missing "PRODUCTION_GCP_PROJECT_ID"
+          [ -n "${{ secrets.PRODUCTION_GKE_LOCATION }}" ] || add_missing "PRODUCTION_GKE_LOCATION"
+          [ -n "${{ secrets.PRODUCTION_GKE_CLUSTER }}" ] || add_missing "PRODUCTION_GKE_CLUSTER"
+          [ -n "${{ secrets.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER }}" ] || add_missing "PRODUCTION_WORKLOAD_IDENTITY_PROVIDER"
+          [ -n "${{ secrets.PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}" ] || add_missing "PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT"
+          [ -n "${{ secrets.PRODUCTION_RUNTIME_GSA_EMAIL }}" ] || add_missing "PRODUCTION_RUNTIME_GSA_EMAIL"
+          toggles=()
+          if ! { [ "${{ vars.PRODUCTION_DEPLOY_ENABLED }}" = "true" ] || [ -z "${{ vars.PRODUCTION_DEPLOY_ENABLED }}" ]; }; then
+            toggles+=("vars.PRODUCTION_DEPLOY_ENABLED")
           fi
+          message="Production deploy skipped."
+          if [ "${#missing[@]}" -gt 0 ]; then
+            message+=" Missing secrets: ${missing[*]}."
+          fi
+          if [ "${#toggles[@]}" -gt 0 ]; then
+            message+=" Enable toggles: ${toggles[*]}."
+          fi
+          echo "::notice::${message}"
 
   deploy:
     name: Deploy to Production
-    needs: provision-check
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.provision-check.outputs.ready == 'true' && (vars.PRODUCTION_DEPLOY_ENABLED == 'true' || vars.PRODUCTION_DEPLOY_ENABLED == '' || vars.PRODUCTION_DEPLOY_ENABLED == null) }}
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && (vars.PRODUCTION_DEPLOY_ENABLED == 'true' || vars.PRODUCTION_DEPLOY_ENABLED == '' || vars.PRODUCTION_DEPLOY_ENABLED == null) && secrets.PRODUCTION_IMAGE_REPO != '' && secrets.PRODUCTION_ARTIFACT_REGISTRY_HOST != '' && secrets.PRODUCTION_GCP_PROJECT_ID != '' && secrets.PRODUCTION_GKE_LOCATION != '' && secrets.PRODUCTION_GKE_CLUSTER != '' && secrets.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.PRODUCTION_WORKLOAD_IDENTITY_SERVICE_ACCOUNT != '' && secrets.PRODUCTION_RUNTIME_GSA_EMAIL != '' }}
     runs-on: ubuntu-latest
     environment: production
     env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,53 +17,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  context:
+    name: Context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Deploy staging workflow triggered on $GITHUB_REF via $GITHUB_EVENT_NAME"
+
   skip:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Staging deploy runs only on main; current ref ${{ github.ref }}."
 
-  provision-check:
-    name: Provision Guard
+  explain-deploy-skip:
+    name: Deploy to Staging (skipped)
+    if: ${{ github.ref == 'refs/heads/main' && !((vars.STAGING_DEPLOY_ENABLED == 'true' || vars.STAGING_DEPLOY_ENABLED == '' || vars.STAGING_DEPLOY_ENABLED == null) && secrets.STAGING_IMAGE_REPO != '' && secrets.STAGING_ARTIFACT_REGISTRY_HOST != '' && secrets.STAGING_GCP_PROJECT_ID != '' && secrets.STAGING_GKE_LOCATION != '' && secrets.STAGING_GKE_CLUSTER != '' && secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT != '' && secrets.STAGING_RUNTIME_GSA_EMAIL != '') }}
     runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.evaluate.outputs.ready }}
-      reason: ${{ steps.evaluate.outputs.reason }}
     steps:
-      - id: evaluate
+      - name: Summarize missing prerequisites
         run: |
           missing=()
-          note() { printf '::notice::%s\n' "$1"; }
-          check_secret() {
-            local key="$1"
-            local value="$2"
-            if [ -z "$value" ]; then
-              missing+=("$key")
-            fi
-          }
-          check_secret "STAGING_IMAGE_REPO" "${{ secrets.STAGING_IMAGE_REPO }}"
-          check_secret "STAGING_ARTIFACT_REGISTRY_HOST" "${{ secrets.STAGING_ARTIFACT_REGISTRY_HOST }}"
-          check_secret "STAGING_GCP_PROJECT_ID" "${{ secrets.STAGING_GCP_PROJECT_ID }}"
-          check_secret "STAGING_GKE_LOCATION" "${{ secrets.STAGING_GKE_LOCATION }}"
-          check_secret "STAGING_GKE_CLUSTER" "${{ secrets.STAGING_GKE_CLUSTER }}"
-          check_secret "STAGING_WORKLOAD_IDENTITY_PROVIDER" "${{ secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER }}"
-          check_secret "STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT" "${{ secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}"
-          check_secret "STAGING_RUNTIME_GSA_EMAIL" "${{ secrets.STAGING_RUNTIME_GSA_EMAIL }}"
-          if [ "${#missing[@]}" -gt 0 ]; then
-            reason="Missing secrets: ${missing[*]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "reason=${reason//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            note "Staging deploy skipped – ${reason}"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "reason=ready" >> "$GITHUB_OUTPUT"
-            note "Staging deploy prerequisites satisfied."
+          add_missing() { missing+=("$1"); }
+          [ -n "${{ secrets.STAGING_IMAGE_REPO }}" ] || add_missing "STAGING_IMAGE_REPO"
+          [ -n "${{ secrets.STAGING_ARTIFACT_REGISTRY_HOST }}" ] || add_missing "STAGING_ARTIFACT_REGISTRY_HOST"
+          [ -n "${{ secrets.STAGING_GCP_PROJECT_ID }}" ] || add_missing "STAGING_GCP_PROJECT_ID"
+          [ -n "${{ secrets.STAGING_GKE_LOCATION }}" ] || add_missing "STAGING_GKE_LOCATION"
+          [ -n "${{ secrets.STAGING_GKE_CLUSTER }}" ] || add_missing "STAGING_GKE_CLUSTER"
+          [ -n "${{ secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER }}" ] || add_missing "STAGING_WORKLOAD_IDENTITY_PROVIDER"
+          [ -n "${{ secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}" ] || add_missing "STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT"
+          [ -n "${{ secrets.STAGING_RUNTIME_GSA_EMAIL }}" ] || add_missing "STAGING_RUNTIME_GSA_EMAIL"
+          toggles=()
+          if ! { [ "${{ vars.STAGING_DEPLOY_ENABLED }}" = "true" ] || [ -z "${{ vars.STAGING_DEPLOY_ENABLED }}" ]; }; then
+            toggles+=("vars.STAGING_DEPLOY_ENABLED")
           fi
+          message="Staging deploy skipped."
+          if [ "${#missing[@]}" -gt 0 ]; then
+            message+=" Missing secrets: ${missing[*]}."
+          fi
+          if [ "${#toggles[@]}" -gt 0 ]; then
+            message+=" Enable toggles: ${toggles[*]}."
+          fi
+          echo "::notice::${message}"
 
   deploy:
     name: Deploy to Staging
-    needs: provision-check
-    if: ${{ github.ref == 'refs/heads/main' && needs.provision-check.outputs.ready == 'true' && (vars.STAGING_DEPLOY_ENABLED == 'true' || vars.STAGING_DEPLOY_ENABLED == '' || vars.STAGING_DEPLOY_ENABLED == null) }}
+    if: ${{ github.ref == 'refs/heads/main' && (vars.STAGING_DEPLOY_ENABLED == 'true' || vars.STAGING_DEPLOY_ENABLED == '' || vars.STAGING_DEPLOY_ENABLED == null) && secrets.STAGING_IMAGE_REPO != '' && secrets.STAGING_ARTIFACT_REGISTRY_HOST != '' && secrets.STAGING_GCP_PROJECT_ID != '' && secrets.STAGING_GKE_LOCATION != '' && secrets.STAGING_GKE_CLUSTER != '' && secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT != '' && secrets.STAGING_RUNTIME_GSA_EMAIL != '' }}
     runs-on: ubuntu-latest
     environment: staging
     env:

--- a/.github/workflows/security-validation-ba.yml
+++ b/.github/workflows/security-validation-ba.yml
@@ -10,50 +10,37 @@ permissions:
   id-token: write
 
 jobs:
+  context:
+    name: Context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Binary Authorization validation triggered on $GITHUB_REF via $GITHUB_EVENT_NAME"
+
   skip:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - run: echo "BA validation runs only on main; current ref ${{ github.ref }}."
 
-  provision-check:
-    name: Provision Guard
+  explain-validation-skip:
+    name: Binary Authorization Validation (skipped)
     runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.evaluate.outputs.ready }}
-      reason: ${{ steps.evaluate.outputs.reason }}
+    if: ${{ secrets.STAGING_GCP_PROJECT_ID == '' || secrets.STAGING_GKE_LOCATION == '' || secrets.STAGING_GKE_CLUSTER == '' || secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER == '' || secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT == '' }}
     steps:
-      - id: evaluate
+      - name: Summarize missing prerequisites
         run: |
           missing=()
-          note() { printf '::notice::%s\n' "$1"; }
-          check_secret() {
-            local key="$1"
-            local value="$2"
-            if [ -z "$value" ]; then
-              missing+=("$key")
-            fi
-          }
-          check_secret "STAGING_GCP_PROJECT_ID" "${{ secrets.STAGING_GCP_PROJECT_ID }}"
-          check_secret "STAGING_GKE_LOCATION" "${{ secrets.STAGING_GKE_LOCATION }}"
-          check_secret "STAGING_GKE_CLUSTER" "${{ secrets.STAGING_GKE_CLUSTER }}"
-          check_secret "STAGING_WORKLOAD_IDENTITY_PROVIDER" "${{ secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER }}"
-          check_secret "STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT" "${{ secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}"
-          if [ "${#missing[@]}" -gt 0 ]; then
-            reason="Missing secrets: ${missing[*]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "reason=${reason//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            note "Binary Authorization validation skipped – ${reason}"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "reason=ready" >> "$GITHUB_OUTPUT"
-            note "Binary Authorization validation prerequisites satisfied."
-          fi
+          add_missing() { missing+=("$1"); }
+          [ -n "${{ secrets.STAGING_GCP_PROJECT_ID }}" ] || add_missing "STAGING_GCP_PROJECT_ID"
+          [ -n "${{ secrets.STAGING_GKE_LOCATION }}" ] || add_missing "STAGING_GKE_LOCATION"
+          [ -n "${{ secrets.STAGING_GKE_CLUSTER }}" ] || add_missing "STAGING_GKE_CLUSTER"
+          [ -n "${{ secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER }}" ] || add_missing "STAGING_WORKLOAD_IDENTITY_PROVIDER"
+          [ -n "${{ secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}" ] || add_missing "STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT"
+          echo "::notice::Binary Authorization validation skipped. Missing secrets: ${missing[*]}."
 
   validate-binary-authorization:
     name: Validate Binary Authorization Enforcement
-    needs: provision-check
-    if: ${{ needs.provision-check.outputs.ready == 'true' }}
+    if: ${{ secrets.STAGING_GCP_PROJECT_ID != '' && secrets.STAGING_GKE_LOCATION != '' && secrets.STAGING_GKE_CLUSTER != '' && secrets.STAGING_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.STAGING_WORKLOAD_IDENTITY_SERVICE_ACCOUNT != '' }}
     runs-on: ubuntu-latest
     environment: staging
     env:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,47 +26,17 @@ env:
   TERRAFORM_VERSION: '1.8.5'
 
 jobs:
+  context:
+    name: Context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::notice::Terraform workflow triggered on $GITHUB_REF via $GITHUB_EVENT_NAME"
+
   skip:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Terraform applies run only on main; current ref ${{ github.ref }}."
-
-  provision-check:
-    name: Provision Guard
-    runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.evaluate.outputs.ready }}
-      reason: ${{ steps.evaluate.outputs.reason }}
-    steps:
-      - id: evaluate
-        run: |
-          missing=()
-          note() { printf '::notice::%s\n' "$1"; }
-          check_secret() {
-            local key="$1"
-            local value="$2"
-            if [ -z "$value" ]; then
-              missing+=("$key")
-            fi
-          }
-          check_secret "TERRAFORM_SERVICE_ACCOUNT" "${{ secrets.TERRAFORM_SERVICE_ACCOUNT }}"
-          check_secret "WORKLOAD_IDENTITY_PROVIDER" "${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}"
-          check_secret "GCP_PROJECT_ID" "${{ secrets.GCP_PROJECT_ID }}"
-          check_secret "GCP_REGION" "${{ secrets.GCP_REGION }}"
-          check_secret "RUNTIME_KSA_NAMESPACE" "${{ secrets.RUNTIME_KSA_NAMESPACE }}"
-          check_secret "RUNTIME_KSA_NAME" "${{ secrets.RUNTIME_KSA_NAME }}"
-          check_secret "BA_ATTESTORS" "${{ secrets.BA_ATTESTORS }}"
-          if [ "${#missing[@]}" -gt 0 ]; then
-            reason="Missing secrets: ${missing[*]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "reason=${reason//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            note "Terraform apply skipped – ${reason}"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "reason=ready" >> "$GITHUB_OUTPUT"
-            note "Terraform apply prerequisites satisfied."
-          fi
 
   plan:
     name: Plan (staging)
@@ -166,10 +136,40 @@ jobs:
           echo "Terraform plan failed"
           exit 1
 
+  explain-apply-skip:
+    name: Terraform Apply (skipped)
+    if: ${{ github.event_name == 'push' && !(((github.ref == 'refs/heads/main' && vars.STAGING_INFRA_ENABLED == 'true') || (startsWith(github.ref, 'refs/tags/v') && vars.PRODUCTION_INFRA_ENABLED == 'true')) && secrets.TERRAFORM_SERVICE_ACCOUNT != '' && secrets.WORKLOAD_IDENTITY_PROVIDER != '' && secrets.GCP_PROJECT_ID != '' && secrets.GCP_REGION != '' && secrets.RUNTIME_KSA_NAMESPACE != '' && secrets.RUNTIME_KSA_NAME != '' && secrets.BA_ATTESTORS != '') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize missing prerequisites
+        run: |
+          missing=()
+          add_missing() { missing+=("$1"); }
+          [ -n "${{ secrets.TERRAFORM_SERVICE_ACCOUNT }}" ] || add_missing "TERRAFORM_SERVICE_ACCOUNT"
+          [ -n "${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}" ] || add_missing "WORKLOAD_IDENTITY_PROVIDER"
+          [ -n "${{ secrets.GCP_PROJECT_ID }}" ] || add_missing "GCP_PROJECT_ID"
+          [ -n "${{ secrets.GCP_REGION }}" ] || add_missing "GCP_REGION"
+          [ -n "${{ secrets.RUNTIME_KSA_NAMESPACE }}" ] || add_missing "RUNTIME_KSA_NAMESPACE"
+          [ -n "${{ secrets.RUNTIME_KSA_NAME }}" ] || add_missing "RUNTIME_KSA_NAME"
+          [ -n "${{ secrets.BA_ATTESTORS }}" ] || add_missing "BA_ATTESTORS"
+          toggles=()
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            [ "${{ vars.STAGING_INFRA_ENABLED }}" = "true" ] || toggles+=("vars.STAGING_INFRA_ENABLED")
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            [ "${{ vars.PRODUCTION_INFRA_ENABLED }}" = "true" ] || toggles+=("vars.PRODUCTION_INFRA_ENABLED")
+          fi
+          message="Terraform apply skipped."
+          if [ "${#missing[@]}" -gt 0 ]; then
+            message+=" Missing secrets: ${missing[*]}."
+          fi
+          if [ "${#toggles[@]}" -gt 0 ]; then
+            message+=" Enable toggles: ${toggles[*]}."
+          fi
+          echo "::notice::${message}"
+
   apply:
     name: Apply
-    needs: provision-check
-    if: ${{ github.event_name == 'push' && needs.provision-check.outputs.ready == 'true' && ((github.ref == 'refs/heads/main' && vars.STAGING_INFRA_ENABLED == 'true') || (startsWith(github.ref, 'refs/tags/v') && vars.PRODUCTION_INFRA_ENABLED == 'true')) }}
+    if: ${{ github.event_name == 'push' && ((github.ref == 'refs/heads/main' && vars.STAGING_INFRA_ENABLED == 'true') || (startsWith(github.ref, 'refs/tags/v') && vars.PRODUCTION_INFRA_ENABLED == 'true')) && secrets.TERRAFORM_SERVICE_ACCOUNT != '' && secrets.WORKLOAD_IDENTITY_PROVIDER != '' && secrets.GCP_PROJECT_ID != '' && secrets.GCP_REGION != '' && secrets.RUNTIME_KSA_NAMESPACE != '' && secrets.RUNTIME_KSA_NAME != '' && secrets.BA_ATTESTORS != '' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'staging' || 'production' }}
     concurrency:


### PR DESCRIPTION
## Summary
- add context jobs to terraform/deploy/security workflows so runs always execute cleanly
- add skip guard jobs that emit notices when required secrets or toggles are missing, preventing push runs from failing noisily
- keep apply/deploy jobs gated on secrets/toggles while documenting skip reasons for administrators

## Testing
- pnpm exec prettier --check .github/workflows/terraform.yml .github/workflows/deploy-staging.yml .github/workflows/deploy-production.yml .github/workflows/security-validation-ba.yml