### PR TITLE
fix: correct cursor download pattern quoting

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -594,7 +594,7 @@ function Get-CursorDownloadCandidatesFromHtml {
         return @()
     }
 
-    $pattern = 'https://downloads\.cursor\.com/[^\s"\\\']+'
+    $pattern = 'https://downloads\.cursor\.com/[^\s"\\'']+'
     $matches = [regex]::Matches($Content, $pattern)
     if ($matches.Count -eq 0) {
         return @()


### PR DESCRIPTION
## Summary
- escape single quote correctly in Cursor download regex so PowerShell parses the script

## Testing
- not run (PowerShell unavailable in container)