### PR TITLE
fix: call cursor fallback helper correctly

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -530,7 +530,7 @@ function Get-CursorInstallerDownloadInfo {
         return $savedMetadata
     }
 
-    foreach ($fallback in Get-CursorStaticDownloadFallbacks()) {
+    foreach ($fallback in (Get-CursorStaticDownloadFallbacks)) {
         if (-not $fallback -or -not $fallback.DownloadUrl) {
             continue
         }


### PR DESCRIPTION
## Summary
- call Get-CursorStaticDownloadFallbacks without parentheses so PowerShell parses correctly

## Testing
- not run (PowerShell unavailable in container)