### PR TITLE
fix/cosign auto 2

### DIFF
--- a/scripts/create-binauthz-attestor.sh
+++ b/scripts/create-binauthz-attestor.sh
@@ -153,9 +153,9 @@ generate_cosign_key() {
   local pwfile log_file
   pwfile="$(mktemp)"
   log_file="$(mktemp)"
-  printf '\n\n' >"$pwfile"
+  printf '' >"$pwfile"
   hash -r
-  if ! COSIGN_PASSWORD="" cosign generate-key-pair --output-key-prefix "$key_prefix" --password-file "$pwfile" --confirm >"$log_file" 2>&1; then
+  if ! COSIGN_PASSWORD="" cosign generate-key-pair --output-key-prefix "$key_prefix" --password-file "$pwfile" >"$log_file" 2>&1; then
     cat "$log_file" >&2
     rm -f "$pwfile" "$log_file"
     echo "Failed to generate Cosign key pair for ${label}. Ensure the directory is writable or provide an existing key." >&2

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -1492,7 +1492,7 @@ function Ensure-WslPackages {
     Write-Section "Installing base packages inside WSL"
     $cmd = @"
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y git ca-certificates curl build-essential python3 python3-pip unzip pkg-config
+DEBIAN_FRONTEND=noninteractive apt-get install -y git ca-certificates curl build-essential python3 python3-pip unzip pkg-config wslu
 "@
     $result = Invoke-Wsl -Command $cmd -AsRoot
     if ($result.ExitCode -ne 0) {


### PR DESCRIPTION
## Summary
- handle cosign installation when sudo is unavailable by falling back to direct download
- generate key pairs with an explicit empty password file, logging cosign output on failure
- ensure wslu is installed in WSL so wslview can launch gcloud OAuth URLs

## Testing
- not run (PowerShell unavailable in container)