### PR TITLE
Fix WSL gcloud login noise and bucket bootstrap

### DIFF
--- a/scripts/bootstrap-infra.sh
+++ b/scripts/bootstrap-infra.sh
@@ -154,8 +154,6 @@ ensure_gcs_bucket() {
 }
 
 
-}
-
 ensure_binary_authorization_attestor() {
   local var_name="$1" env_label="$2"
   if [[ -z "$var_name" || -z "$env_label" ]]; then


### PR DESCRIPTION
## Summary
- remove the extra brace in `scripts/bootstrap-infra.sh` that broke Terraform bootstrap with a syntax error
- rewrite the Windows URL relay script to avoid wslview/registry noise and launch gcloud URLs via PowerShell/cmd
- improve `Invoke-Wsl` logging so stderr lines show the real message instead of `System.Management.Automation.RemoteException`

## Testing
- lint-staged (pre-commit)
