### PR TITLE
Fix terraform auto-approve and Cursor fallback

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -1418,9 +1418,9 @@ function Ensure-CursorExtensions {
 
     $cliPath = Get-CursorCliPath -CursorExePath $cursorPath
     if (-not $cliPath -or -not (Test-Path $cliPath)) {
-        Write-Warning "Cursor command-line interface not found. Install extensions manually via the Cursor marketplace."
-        Write-CursorLog "Cursor CLI not found; extension installation skipped."
-        return
+        Write-Warning "Cursor command-line interface not found; attempting VSIX-based installation instead."
+        Write-CursorLog "Cursor CLI not found; falling back to VSIX/manual extension installation."
+        $cliPath = $null
     }
 
     $targets = @(


### PR DESCRIPTION
## Summary
- detect AUTO_APPROVE/TF_IN_AUTOMATION in bootstrap script and pass -auto-approve without prompting
- allow VSIX/manual Cursor extension installation even when the CLI binary is missing

## Testing
- lint-staged (pre-commit)
