### PR TITLE
Add full reset option to uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,11 @@ To wipe generated state (caches, node_modules, extension locks) run:
 ```
 
 Add `--destroy-cloud` to tear down Terraform-managed infrastructure (ensure you have credentials and intend to remove cloud resources).
+
+If you need to revert the machine completely—removing Cursor, Docker Desktop, the WSL distribution, and all cached state—run:
+
+```bash
+./scripts/uninstall.sh --full-reset
+```
+
+The helper generates and launches an elevated Windows PowerShell cleanup that uninstalls the host tooling and unregisters the WSL distro. A confirmation prompt from Windows User Account Control will appear; after it completes, reboot to return the PC to its pre-installation state.


### PR DESCRIPTION
## Summary
- add  mode to [23:20:55] Uninstall script initialised (dry-run=0, force=0) (elapsed 0s) that generates a Windows host cleanup script and launches it with elevation
- host cleanup removes Cursor, Docker Desktop, known WSL distributions, and clears related caches/environment variables
- update README usage docs to explain the new flag and behaviour

## Testing
- lint-staged (pre-commit)
- ./scripts/uninstall.sh --dry-run --full-reset
