### PR TITLE
Fix full reset host launcher quoting

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -680,7 +680,7 @@ launch_host_cleanup_script() {
   else
     win_path="C:\\ProgramData\\ai-dev-platform\\uninstall-host.ps1"
   fi
-  local command="Start-Process -FilePath 'PowerShell.exe' -Verb RunAs -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-File','${win_path}','-Elevated')"
+  local command="Start-Process -FilePath 'PowerShell.exe' -Verb RunAs -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','$win_path','-Elevated'"
   if powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$command" >/dev/null 2>&1; then
     log_phase "Windows host cleanup launched (administrator approval required)."
   else


### PR DESCRIPTION
## Summary
- update the  launcher to pass the resolved Windows path into Start-Process so PowerShell executes the generated host cleanup script instead of prompting for an app

## Testing
- ./scripts/uninstall.sh --dry-run --full-reset
