### PR TITLE
Run host reset script directly

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -680,8 +680,7 @@ launch_host_cleanup_script() {
   else
     win_path="C:\\ProgramData\\ai-dev-platform\\uninstall-host.ps1"
   fi
-  local command="Start-Process -FilePath 'PowerShell.exe' -Verb RunAs -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','$win_path','-Elevated'"
-  if powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$command" >/dev/null 2>&1; then
+  if powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$win_path" >/dev/null 2>&1; then
     log_phase "Windows host cleanup launched (administrator approval required)."
   else
     local fallback="$win_path"


### PR DESCRIPTION
## Summary
- invoke the generated Windows cleanup script with  so it executes immediately and self-elevates, instead of launching  (which produced an open-with prompt on some systems)

## Testing
- ./scripts/uninstall.sh --dry-run --full-reset
