### PR TITLE
Launch host cleanup with Start-Process command

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -21,7 +21,7 @@ TELEMETRY=0
 FULL_RESET=0
 HOST_SCRIPT_CREATED=0
 HOST_SCRIPT_PATH_UNIX=""
-HOST_INVOKER_PATH_UNIX=""
+HOST_COMMAND=""
 START_TIME=$SECONDS
 declare -a DRY_RUN_REPORT=()
 
@@ -534,7 +534,6 @@ generate_host_cleanup_script() {
     mkdir -p "$host_root"
   fi
   local script_path="$host_root/uninstall-host.ps1"
-  local invoker_path="$host_root/invoke-uninstall-host.ps1"
   cat <<'POWERSHELL' >"$script_path"
 [CmdletBinding()]
 param(
@@ -661,21 +660,9 @@ try {
     Write-Warn "Unable to delete cleanup script: $($_.Exception.Message)"
 }
 POWERSHELL
-  cat <<'POWERSHELL' >"$invoker_path"
-[CmdletBinding()]
-param(
-    [string]$ScriptPath = "$PSScriptRoot\uninstall-host.ps1"
-)
-if (-not (Test-Path $ScriptPath)) {
-    Write-Error "Host cleanup script not found: $ScriptPath"
-    exit 1
-}
-Start-Process -FilePath 'PowerShell.exe' -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File', $ScriptPath -Verb RunAs
-POWERSHELL
-  chmod 0600 "$invoker_path"
   chmod 0600 "$script_path"
   HOST_SCRIPT_PATH_UNIX="$script_path"
-  HOST_INVOKER_PATH_UNIX="$invoker_path"
+  HOST_COMMAND=""
   HOST_SCRIPT_CREATED=1
 }
 
@@ -690,15 +677,13 @@ launch_host_cleanup_script() {
     return
   fi
   local win_path
-  local invoker_win_path
   if command -v wslpath >/dev/null 2>&1; then
     win_path=$(wslpath -w "$HOST_SCRIPT_PATH_UNIX")
-    invoker_win_path=$(wslpath -w "$HOST_INVOKER_PATH_UNIX")
   else
     win_path="C:\\ProgramData\\ai-dev-platform\\uninstall-host.ps1"
-    invoker_win_path="C:\\ProgramData\\ai-dev-platform\\invoke-uninstall-host.ps1"
   fi
-  if powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$invoker_win_path" >/dev/null 2>&1; then
+  local ps_command="Start-Process PowerShell.exe -Verb RunAs -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','${win_path}'"
+  if powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ps_command" >/dev/null 2>&1; then
     log_phase "Windows host cleanup launched (administrator approval required)."
   else
     local fallback="$win_path"


### PR DESCRIPTION
## Summary
- invoke PowerShell directly with a Start-Process command so the host cleanup script self-elevates without triggering Windows' 'select an app' prompt

## Testing
- ./scripts/uninstall.sh --dry-run --full-reset
