### PR TITLE
Add PowerShell wrapper for full reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,3 +373,11 @@ If you need to revert the machine completely—removing Cursor, Docker Desktop, 
 ```
 
 The helper generates and launches an elevated Windows PowerShell cleanup that uninstalls the host tooling and unregisters the WSL distro. A confirmation prompt from Windows User Account Control will appear; after it completes, reboot to return the PC to its pre-installation state.
+
+Prefer launching the reset from Windows PowerShell? Invoke the wrapper at the repository root:
+
+```powershell
+.\Reset-AiDevPlatform.ps1
+```
+
+It shells into WSL to execute the same full-reset flow (honouring `-DryRun` or `-DestroyCloud` flags) and surfaces the Windows UAC prompt automatically.

--- a/Reset-AiDevPlatform.ps1
+++ b/Reset-AiDevPlatform.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+  Runs the full AI Dev Platform uninstall from Windows PowerShell.
+
+.DESCRIPTION
+  Wrapper that invokes the existing Linux-side uninstall script inside WSL and
+  triggers the Windows host cleanup. Use this when you want to reset a machine
+  without opening a WSL shell manually.
+
+.PARAMETER DryRun
+  Show actions without deleting anything.
+
+.PARAMETER DestroyCloud
+  Run terraform destroy for each environment before removing local state.
+
+.PARAMETER SkipConfirm
+  Suppress the final confirmation message before running.
+
+.EXAMPLE
+  PS> .\Reset-AiDevPlatform.ps1
+
+.EXAMPLE
+  PS> .\Reset-AiDevPlatform.ps1 -DestroyCloud -DryRun
+#>
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [switch]$DestroyCloud,
+    [switch]$SkipConfirm
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+    throw "WSL is not installed or wsl.exe cannot be found. Install/enable WSL before running the reset."
+}
+
+$repoRoot = if ($PSCommandPath) { Split-Path -Parent $PSCommandPath } else { Get-Location }
+$repoRoot = (Resolve-Path $repoRoot).ProviderPath
+
+$uninstallScript = Join-Path $repoRoot "scripts\uninstall.sh"
+if (-not (Test-Path $uninstallScript)) {
+    throw "Unable to locate scripts\uninstall.sh under $repoRoot. Run this script from the repository checkout."
+}
+
+$wslPath = (& wsl.exe wslpath -a $repoRoot) 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($wslPath)) {
+    throw "Failed to translate $repoRoot into a WSL path. Ensure the WSL distribution is installed and running."
+}
+$wslPath = $wslPath.Trim()
+
+$commandArgs = [System.Collections.Generic.List[string]]::new()
+$commandArgs.Add("./scripts/uninstall.sh")
+$commandArgs.Add("--full-reset")
+$commandArgs.Add("--force")
+if ($DryRun)      { $commandArgs.Add("--dry-run") }
+if ($DestroyCloud) { $commandArgs.Add("--destroy-cloud") }
+
+$commandString = [string]::Join(" ", $commandArgs)
+
+$escapeSingleQuote = { param($text) $text -replace "'", "'\''" }
+$wslPathEscaped = & $escapeSingleQuote $wslPath
+$commandEscaped = & $escapeSingleQuote $commandString
+$fullCommand = "cd '$wslPathEscaped' && $commandEscaped"
+
+if (-not $SkipConfirm) {
+    Write-Host "This will remove repository artifacts, cached data, and launch the Windows cleanup helper." -ForegroundColor Yellow
+    $answer = Read-Host "Continue? [Y/n]"
+    if ($answer -and $answer.Trim() -notmatch '^(y|yes)$') {
+        Write-Host "Aborted by user."
+        return
+    }
+}
+
+Write-Host "Executing uninstall inside WSL..." -ForegroundColor Cyan
+& wsl.exe -- bash -lc "$fullCommand"
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    throw "WSL uninstall script exited with code $exitCode. Review the output above for details."
+}
+
+Write-Host ""
+Write-Host "WSL uninstall completed. Approve the Windows UAC prompt (if shown) to finish removing host applications." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add  so Windows users can kick off the full uninstall from PowerShell (it shells into WSL and reuses )
- update README reset section with the new wrapper command

## Testing
- lint-staged (pre-commit)
- .\Reset-AiDevPlatform.ps1 -DryRun
