### PR TITLE
Fix WSL path normalization

### DIFF
--- a/Reset-AiDevPlatform.ps1
+++ b/Reset-AiDevPlatform.ps1
@@ -40,8 +40,10 @@ function Convert-WindowsPathToWsl {
     $resolved = [System.IO.Path]::GetFullPath($Path)
     if ($resolved -match '^[A-Za-z]:\\') {
         $drive = $resolved.Substring(0,1).ToLowerInvariant()
-        $rest = $resolved.Substring(2).Replace('\\','/')
-        return ("/mnt/{0}/{1}" -f $drive, $rest).Replace('//','/')
+        $rest = $resolved.Substring(2)
+        $rest = $rest.TrimStart('\')
+        $rest = $rest.Replace('\\','/')
+        return "/mnt/$drive/$rest"
     }
     return $resolved.Replace('\\','/')
 }


### PR DESCRIPTION
## Summary
- trim the leading backslash when converting Windows paths to WSL paths so the reset wrapper can cd into /mnt/<drive>/...

## Testing
- powershell.exe -ExecutionPolicy Bypass -File .\Reset-AiDevPlatform.ps1 -DryRun
