### PR TITLE
Fix WSL forward slash conversion

### DIFF
--- a/Reset-AiDevPlatform.ps1
+++ b/Reset-AiDevPlatform.ps1
@@ -42,10 +42,10 @@ function Convert-WindowsPathToWsl {
         $drive = $resolved.Substring(0,1).ToLowerInvariant()
         $rest = $resolved.Substring(2)
         $rest = $rest.TrimStart('\')
-        $rest = $rest.Replace('\\','/')
+        $rest = $rest -replace '\\','/'
         return "/mnt/$drive/$rest"
     }
-    return $resolved.Replace('\\','/')
+    return ($resolved -replace '\\','/')
 }
 
 if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
## Summary
- use  to convert Windows path separators to forward slashes in the PowerShell reset wrapper, avoiding mixed backslashes in the WSL path

## Testing
- powershell.exe -ExecutionPolicy Bypass -File .\Reset-AiDevPlatform.ps1 -DryRun
