### PR TITLE
Fix CRLF cleanup in reset wrapper

### DIFF
--- a/Reset-AiDevPlatform.ps1
+++ b/Reset-AiDevPlatform.ps1
@@ -88,6 +88,10 @@ if (-not $SkipConfirm) {
     }
 }
 
+# convert any CRLF endings in shell scripts to LF before executing
+$sanitizeCommand = "cd '$wslPathEscaped' && find . -type f -name '*.sh' -print0 | xargs -0 -n 1 sed -i 's/\\r$//'"
+& wsl.exe -- bash -lc "$sanitizeCommand" 2>$null | Out-Null
+
 Write-Host "Executing uninstall inside WSL..." -ForegroundColor Cyan
 & wsl.exe -- bash -lc "$fullCommand"
 $exitCode = $LASTEXITCODE


### PR DESCRIPTION
## Summary
- run a CRLF strip () on all shell scripts before invoking the uninstall in WSL
- fixes  when the repo is checked out with Windows line endings

## Testing
- powershell.exe -ExecutionPolicy Bypass -File .\Reset-AiDevPlatform.ps1 -DryRun
