### PR TITLE
Normalize shell scripts before reset

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Reset-AiDevPlatform.ps1
+++ b/Reset-AiDevPlatform.ps1
@@ -88,6 +88,15 @@ if (-not $SkipConfirm) {
     }
 }
 
+
+$sanitizeCommand = @"
+cd '$wslPathEscaped'
+if command -v find >/dev/null 2>&1; then
+  find . -type f -name '*.sh' -exec sed -i 's/\r$//' {} +
+fi
+"@
+& wsl.exe -- bash -lc $sanitizeCommand | Out-Null
+
 Write-Host "Executing uninstall inside WSL..." -ForegroundColor Cyan
 & wsl.exe -- bash -lc "$fullCommand"
 $exitCode = $LASTEXITCODE


### PR DESCRIPTION
## Summary
- add a  entry so  are always checked out with LF endings
- in the reset PowerShell wrapper, run a quick  pass inside WSL to strip CRLF before invoking the uninstall script

## Testing
- powershell.exe -ExecutionPolicy Bypass -File .\Reset-AiDevPlatform.ps1 -DryRun
