### PR TITLE
Skip terraform destroy by default in reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Prefer launching the reset from Windows PowerShell? Invoke the wrapper at the re
 .\Reset-AiDevPlatform.ps1
 ```
 
-It shells into WSL to execute the same full-reset flow (honouring `-DryRun` or `-DestroyCloud` flags) and surfaces the Windows UAC prompt automatically.
+It shells into WSL to execute the same full-reset flow (honouring `-DryRun` or `-DestroyCloud` flags) and surfaces the Windows UAC prompt automatically. By default it skips Terraform `destroy`; add `-DestroyCloud` if you truly want to tear down the GCP infrastructure as well.
 If PowerShell blocks the script with an execution-policy warning, bypass it for the current session:
 
 ```powershell

--- a/Reset-AiDevPlatform.ps1
+++ b/Reset-AiDevPlatform.ps1
@@ -70,8 +70,9 @@ $commandArgs = [System.Collections.Generic.List[string]]::new()
 $commandArgs.Add("./scripts/uninstall.sh")
 $commandArgs.Add("--full-reset")
 $commandArgs.Add("--force")
-if ($DryRun)      { $commandArgs.Add("--dry-run") }
-if ($DestroyCloud) { $commandArgs.Add("--destroy-cloud") }
+if ($DryRun)        { $commandArgs.Add("--dry-run") }
+if ($DestroyCloud)  { $commandArgs.Add("--destroy-cloud") }
+else                { $commandArgs.Add("--skip-destroy-cloud") }
 
 $commandString = [string]::Join(" ", $commandArgs)
 


### PR DESCRIPTION
## Summary
- pass  unless the user explicitly sets 
- document the default behaviour in the README so the wrapper is foolproof out-of-the-box

## Testing
- powershell.exe -ExecutionPolicy Bypass -File .\Reset-AiDevPlatform.ps1 -DryRun
