### PR TITLE
Auto clean sync sandbox working tree

### DIFF
--- a/sync-sandbox.ps1
+++ b/sync-sandbox.ps1
@@ -61,7 +61,12 @@ try {
 
     $gitStatus = git status --porcelain
     if ($gitStatus) {
-        throw "Working tree is not clean. Commit or stash changes before synchronization."
+        Write-Host "Working tree contains local changes; resetting to a clean state..." -ForegroundColor Yellow
+        git reset --hard HEAD
+        git clean -fd
+        if (git status --porcelain) {
+            throw "Unable to clean working tree automatically. Resolve manually and rerun."
+        }
     }
 
     git checkout main


### PR DESCRIPTION
## Summary
- if  detects local changes it now runs HEAD is now at 7157961 feat: skip terraform destroy by default in reset (#96) and Removing --/
Removing -tmp/ automatically
- ensures a full sync can proceed even after automation or uninstall scripts touch the checkout

## Testing
- git status --porcelain (dirty)
- .\sync-sandbox.ps1  # verifies cleanup path
