### PR TITLE
fix: restore working directory after teardown

### DIFF
--- a/FullTeardown-AiDevPlatform.ps1
+++ b/FullTeardown-AiDevPlatform.ps1
@@ -850,7 +850,7 @@ if (-not $SkipConfirm) {
     }
 }
 
-$initialLocation = Get-Location
+$initialPath = (Get-Location).Path
 $locationPushed  = $false
 
 $issues = [System.Collections.Generic.List[string]]::new()
@@ -1071,7 +1071,7 @@ finally {
     if ($locationPushed) {
         try { Pop-Location | Out-Null } catch {}
     }
-    if ($initialLocation) {
-        try { Set-Location -LiteralPath $initialLocation.Path } catch {}
+    if ($initialPath) {
+        try { Set-Location -LiteralPath $initialPath } catch {}
     }
 }

--- a/Reset-AiDevPlatform.ps1
+++ b/Reset-AiDevPlatform.ps1
@@ -284,7 +284,7 @@ if (-not $DryRun) {
     if (Test-CommandAvailable "gh") {
         Invoke-GitHubForkDeletion -OriginSlug $originSlug -UpstreamSlug $upstreamSlug
     }
-    $originalLocation = Get-Location
+    $originalPath = (Get-Location).Path
     $locationPushed = $false
     try {
         $repoParent = Split-Path -LiteralPath $repoRoot -Parent
@@ -296,8 +296,8 @@ if (-not $DryRun) {
     } finally {
         if ($locationPushed) {
             Pop-Location | Out-Null
-        } elseif ($originalLocation) {
-            try { Set-Location -LiteralPath $originalLocation.Path } catch {}
+        } elseif ($originalPath) {
+            try { Set-Location -LiteralPath $originalPath } catch {}
         }
     }
 } else {


### PR DESCRIPTION
## Summary
- store the original working directory path as a string and restore it safely in FullTeardown-AiDevPlatform.ps1
- apply the same fix to Reset-AiDevPlatform.ps1 so dry-run executions no longer throw when resetting location

## Testing
- lint-staged (auto via commit)
