### PR TITLE
fix: use Get-Item for path restoration

### DIFF
--- a/FullTeardown-AiDevPlatform.ps1
+++ b/FullTeardown-AiDevPlatform.ps1
@@ -850,7 +850,7 @@ if (-not $SkipConfirm) {
     }
 }
 
-$initialPath = (Get-Location).Path
+$initialPath = (Get-Item -LiteralPath '.' -ErrorAction Stop).FullName
 $locationPushed  = $false
 
 $issues = [System.Collections.Generic.List[string]]::new()

--- a/Reset-AiDevPlatform.ps1
+++ b/Reset-AiDevPlatform.ps1
@@ -284,7 +284,7 @@ if (-not $DryRun) {
     if (Test-CommandAvailable "gh") {
         Invoke-GitHubForkDeletion -OriginSlug $originSlug -UpstreamSlug $upstreamSlug
     }
-    $originalPath = (Get-Location).Path
+    $originalPath = (Get-Item -LiteralPath '.' -ErrorAction Stop).FullName
     $locationPushed = $false
     try {
         $repoParent = Split-Path -LiteralPath $repoRoot -Parent


### PR DESCRIPTION
## Summary
- replace (Get-Location).Path with (Get-Item -LiteralPath '.') in both teardown scripts so the current directory is recorded reliably under StrictMode

## Testing
- lint-staged (auto via commit)
