### PR TITLE
fix: avoid strict mode property errors

### DIFF
--- a/FullTeardown-AiDevPlatform.ps1
+++ b/FullTeardown-AiDevPlatform.ps1
@@ -192,8 +192,8 @@ function Acquire-AiDevRepo {
         if (-not $value) { $value = [Environment]::GetEnvironmentVariable($envName,'Machine') }
         Add-UniqueString -List $candidates -Value $value
     }
-    if ($MyInvocation.MyCommand.Path) {
-        Add-UniqueString -List $candidates -Value (Split-Path -Parent $MyInvocation.MyCommand.Path)
+    if ($PSScriptRoot) {
+        Add-UniqueString -List $candidates -Value $PSScriptRoot
     }
     try {
         $pwdCandidate = (Get-Item -LiteralPath '.' -ErrorAction Stop).FullName


### PR DESCRIPTION
## Summary
- use PSScriptRoot when seeding candidate paths so strict mode doesn’t access MyInvocation.MyCommand.Path
- continue to rely on Get-Item for full paths to avoid ProviderPath usage

## Testing
- lint-staged (auto via commit)
