### PR TITLE
fix: guard teardown Set-Location call

### DIFF
--- a/FullTeardown-AiDevPlatform.ps1
+++ b/FullTeardown-AiDevPlatform.ps1
@@ -1092,6 +1092,14 @@ finally {
         try { Pop-Location | Out-Null } catch {}
     }
     if ($initialLocation) {
-        try { Set-Location -LiteralPath $initialLocation.Path } catch {}
+        $initialPath = $null
+        if ($initialLocation -is [System.Management.Automation.PathInfo]) {
+            $initialPath = $initialLocation.Path
+        } else {
+            $initialPath = [string]$initialLocation
+        }
+        if ($initialPath) {
+            try { Set-Location -LiteralPath $initialPath } catch {}
+        }
     }
 }


### PR DESCRIPTION
## Summary
- guard the final Set-Location call so teardown works when Get-Location returns a string
- prevent PropertyNotFoundException when running FullTeardown-AiDevPlatform.ps1

## Testing
- not run (not requested)
