### PR TITLE
fix: correct wsl quoting in teardown

### DIFF
--- a/FullTeardown-AiDevPlatform.ps1
+++ b/FullTeardown-AiDevPlatform.ps1
@@ -498,12 +498,12 @@ function Invoke-WslBlock {
         $normalized = ($exports -join "`n") + "`n" + $normalized
     }
 
-    $escapedNormalized = $normalized.Replace('"','\"')
+    $escapedNormalized = $normalized.Replace('"','""')
     $cmdExecutable = $env:ComSpec
     if ([string]::IsNullOrWhiteSpace($cmdExecutable)) {
         $cmdExecutable = "cmd.exe"
     }
-    $innerCommand = "wsl.exe -- bash -lc ""$escapedNormalized"" 2>&1"
+    $innerCommand = '""wsl.exe" -- bash -lc "{0}" 2>&1"' -f $escapedNormalized
 
     $previousPreference = $ErrorActionPreference
     try {


### PR DESCRIPTION
## Summary
- escape double quotes using cmd-safe doubling before invoking wsl
- keep stderr tolerant execution while avoiding bash parsing errors

## Testing
- not run (Windows-only change)
