### PR TITLE
Handle malformed GitHub CLI source in WSL bootstrap

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2167,6 +2167,12 @@ function Test-NetworkConnectivity {
 function Ensure-WslPackages {
     Write-Section "Installing base packages inside WSL"
     $cmd = @"
+if [ -f /etc/apt/sources.list.d/github-cli.list ]; then
+  if ! grep -Eq '^deb \[arch=[^[:space:]]+ signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg\] https://cli.github.com/packages stable main$' /etc/apt/sources.list.d/github-cli.list; then
+    echo "Removing malformed GitHub CLI apt source definition" >&2
+    rm -f /etc/apt/sources.list.d/github-cli.list
+  fi
+fi
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y git ca-certificates curl build-essential python3 python3-pip unzip pkg-config wslu
 "@


### PR DESCRIPTION
## Summary
- drop a malformed `/etc/apt/sources.list.d/github-cli.list` before running `apt-get update` inside WSL during bootstrap
- prevents `apt-get update` from failing with `[option] no value` when the file is corrupted

## Testing
- powershell -NoProfile -ExecutionPolicy RemoteSigned -File .\scripts\windows\setup.ps1 (previously failed, now succeeds)
