### PR TITLE
Simplify GH CLI source guard

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2168,7 +2168,8 @@ function Ensure-WslPackages {
     Write-Section "Installing base packages inside WSL"
     $cmd = @"
 if [ -f /etc/apt/sources.list.d/github-cli.list ]; then
-  if ! grep -Eq '^deb \[arch=[^[:space:]]+ signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg\] https://cli.github.com/packages stable main$' /etc/apt/sources.list.d/github-cli.list; then
+  if ! grep -q "https://cli.github.com/packages stable main" /etc/apt/sources.list.d/github-cli.list || \
+     ! grep -q "signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg" /etc/apt/sources.list.d/github-cli.list; then
     echo "Removing malformed GitHub CLI apt source definition" >&2
     rm -f /etc/apt/sources.list.d/github-cli.list
   fi


### PR DESCRIPTION
## Summary
- treat the WSL github-cli apt source as malformed unless it contains both the expected repo URL and signed-by stanza
- avoids brittle regex that broke bash execution when run via the bootstrap

## Testing
- powershell -NoProfile -ExecutionPolicy RemoteSigned -File .\scripts\windows\setup.ps1
