### PR TITLE
Avoid multiline escaping in WSL GH CLI guard

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2168,8 +2168,7 @@ function Ensure-WslPackages {
     Write-Section "Installing base packages inside WSL"
     $cmd = @"
 if [ -f /etc/apt/sources.list.d/github-cli.list ]; then
-  if ! grep -q "https://cli.github.com/packages stable main" /etc/apt/sources.list.d/github-cli.list || \
-     ! grep -q "signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg" /etc/apt/sources.list.d/github-cli.list; then
+  if ! grep -q "https://cli.github.com/packages stable main" /etc/apt/sources.list.d/github-cli.list || ! grep -q "signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg" /etc/apt/sources.list.d/github-cli.list; then
     echo "Removing malformed GitHub CLI apt source definition" >&2
     rm -f /etc/apt/sources.list.d/github-cli.list
   fi


### PR DESCRIPTION
## Summary
- rewrite the github-cli list guard to keep the `||` on a single line
- prevents bash from choking on CRLF line continuations when launched via `bash -lc`

## Testing
- powershell -NoProfile -ExecutionPolicy RemoteSigned -File .\scripts\windows\setup.ps1 (passes)
