### PR TITLE
Escape WSL bootstrap quotes

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2190,7 +2190,8 @@ if ! apt-get update; then
 fi
 DEBIAN_FRONTEND=noninteractive apt-get install -y git ca-certificates curl build-essential python3 python3-pip unzip pkg-config wslu
 '@
-    $result = Invoke-Wsl -Command $cmd -AsRoot
+    $escapedCmd = $cmd.Replace('"','\"')
+    $result = Invoke-Wsl -Command $escapedCmd -AsRoot
     if ($result.ExitCode -ne 0) {
         throw "Failed to install base packages in WSL (exit $($result.ExitCode))."
     }


### PR DESCRIPTION
## Summary
- escape embedded double quotes before passing the bootstrap script to `wsl.exe`
- prevents Windows argument parsing from stripping quotes and splitting the script into bogus commands

## Testing
- docker run --rm ubuntu:22.04 bash -lc "set -euo pipefail; $(python3 - <<'PY'
import re
from pathlib import Path
text = Path('scripts/windows/setup.ps1').read_text()
m = re.search(r"\$cmd\s*=\s*@'\n(.*?)\n'@", text, re.S)
cmd = m.group(1).rstrip('\n')
cmd = cmd.replace('"','\\"')
print(cmd)
PY)"
