### PR TITLE
Write WSL scripts via heredoc

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2190,8 +2190,12 @@ if ! apt-get update; then
 fi
 DEBIAN_FRONTEND=noninteractive apt-get install -y git ca-certificates curl build-essential python3 python3-pip unzip pkg-config wslu
 '@
-    $encodedScript = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($scriptContent))
-    $command = "printf '%s' '$encodedScript' | base64 -d | bash"
+    $command = @"
+cat <<'__CODA__' >/tmp/ensure-wsl-packages.sh
+$scriptContent
+__CODA__
+bash /tmp/ensure-wsl-packages.sh
+"@
     $result = Invoke-Wsl -Command $command -AsRoot
     if ($result.ExitCode -ne 0) {
         throw "Failed to install base packages in WSL (exit $($result.ExitCode))."
@@ -2216,8 +2220,12 @@ printf "deb [arch=%s signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y gh
 '@
-    $encodedInstallScript = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($installScript))
-    $installCommand = "printf '%s' '$encodedInstallScript' | base64 -d | bash"
+    $installCommand = @"
+cat <<'__CODA__' >/tmp/install-gh-cli.sh
+$installScript
+__CODA__
+bash /tmp/install-gh-cli.sh
+"@
     $installResult = Invoke-Wsl -Command $installCommand -AsRoot
     if ($installResult.ExitCode -ne 0) {
         throw "Failed to install GitHub CLI inside WSL (exit $($installResult.ExitCode))."


### PR DESCRIPTION
## Summary
- stream the WSL bootstrap snippet into `/tmp/ensure-wsl-packages.sh` with a quoted heredoc so Windows cannot corrupt quoting
- do the same for the GitHub CLI installer, removing the dependency on inline base64 or Python availability inside WSL

## Testing
- docker run --rm ubuntu:22.04 bash -lc "cat <<'__CODA__' >/tmp/script.sh
$(python3 - <<'PY'
import re
from pathlib import Path
text = Path('scripts/windows/setup.ps1').read_text()
script = re.search(r"\$scriptContent\s*=\s*@'\n(.*?)\n'@", text, re.S).group(1)
print(script)
PY)
__CODA__
bash /tmp/script.sh"
