### PR TITLE
Execute WSL bootstrap via base64

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2191,14 +2191,12 @@ fi
 DEBIAN_FRONTEND=noninteractive apt-get install -y git ca-certificates curl build-essential python3 python3-pip unzip pkg-config wslu
 '@
     $normalizedScript = $scriptContent.Replace("`r","")
-    $commandTemplate = @'
-cat <<'__CODA__' >/tmp/ensure-wsl-packages.sh
-__SCRIPT_CONTENT__
+    $encodedScript = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($normalizedScript))
+    $command = @"
+base64 -d <<'__CODA__' | bash
+$encodedScript
 __CODA__
-bash /tmp/ensure-wsl-packages.sh
-rm -f /tmp/ensure-wsl-packages.sh
-'@
-    $command = $commandTemplate.Replace("__SCRIPT_CONTENT__", $normalizedScript)
+"@
     $command = $command.Replace("`r","")
     $result = Invoke-Wsl -Command $command -AsRoot
     if ($result.ExitCode -ne 0) {
@@ -2225,14 +2223,12 @@ apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y gh
 '@
     $normalizedInstall = $installScript.Replace("`r","")
-    $installTemplate = @'
-cat <<'__CODA__' >/tmp/install-gh-cli.sh
-__SCRIPT_CONTENT__
+    $encodedInstall = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($normalizedInstall))
+    $installCommand = @"
+base64 -d <<'__CODA__' | bash
+$encodedInstall
 __CODA__
-bash /tmp/install-gh-cli.sh
-rm -f /tmp/install-gh-cli.sh
-'@
-    $installCommand = $installTemplate.Replace("__SCRIPT_CONTENT__", $normalizedInstall)
+"@
     $installCommand = $installCommand.Replace("`r","")
     $installResult = Invoke-Wsl -Command $installCommand -AsRoot
     if ($installResult.ExitCode -ne 0) {


### PR DESCRIPTION
## Summary
- ship the WSL bootstrap and GitHub CLI installer scripts by piping base64-decoded content directly into `bash`
- avoids heredoc truncation from Windows CRLF or `$()` expansion while keeping the scripts literal

## Testing
- docker run --rm ubuntu:22.04 bash -lc "base64 -d <<'__CODA__' | bash
$(python3 - <<'PY'
import re, base64
from pathlib import Path
text = Path('scripts/windows/setup.ps1').read_text()
script = re.search(r"\$scriptContent\s*=\s*@'\n(.*?)\n'@", text, re.S).group(1).replace('\r','')
print(base64.b64encode(script.encode()).decode())
PY)
__CODA__"
