### PR TITLE
Relax GitHub hardening requirements

### DIFF
--- a/scripts/setup-all.sh
+++ b/scripts/setup-all.sh
@@ -181,6 +181,10 @@ execute_step() {
     return 0
   fi
   local status=$?
+  if (( status == 3 )); then
+    log "${label} skipped (see guidance above)."
+    return 0
+  fi
   record_failure "${label} failed with exit status ${status}"
   printf '\n%s failed with exit status %d. Review the output above, resolve the issue, then rerun this script.\n' "$label" "$status" >&2
   exit "$status"


### PR DESCRIPTION
## Summary
- trim the GitHub CLI scope requirement down to `repo,workflow` by default; `admin:org` is now requested only when the repository owner is an organization
- allow users without admin access to skip repository hardening interactively; the setup prints follow-up instructions instead of looping forever
- teach the aggregated `setup-all.sh` runner to treat exit code 3 as "skipped" so the overall bootstrap can complete while leaving guidance for manual follow-up

## Testing
- ./scripts/github-hardening.sh (with insufficient scopes and choosing skip)
- ./scripts/setup-all.sh (verifies skip returns control, pending notice printed)
