### PR TITLE
Use GH_TOKEN for automatic hardening

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2808,7 +2808,7 @@ if (-not $SkipDockerInstall) {
 Ensure-Repository
 
 if (-not $SkipSetupAll) {
-    $ghTokenAdded = Prompt-OptionalToken -EnvName "GH_TOKEN" -PromptMessage "Optional GitHub token to streamline gh auth"
+    $ghTokenAdded = Prompt-OptionalToken -EnvName "GH_TOKEN" -PromptMessage "Optional GitHub token (scopes: repo,workflow; add admin:org for org repos)"
     $infTokenAdded = Prompt-OptionalToken -EnvName "INFISICAL_TOKEN" -PromptMessage "Optional Infisical token"
     Run-SetupAll
     if ($ghTokenAdded) { Remove-Item -Path Env:GH_TOKEN -ErrorAction SilentlyContinue }


### PR DESCRIPTION
## Summary
- detect tokens provided through `GH_TOKEN`/`SETUP_GITHUB_TOKEN` and use them with `gh auth login --with-token`
- fall back to at most one interactive refresh; if scopes/admin access still missing, skip hardening with guidance
- update the Windows bootstrap prompt to note the required scopes so new users can paste a correct PAT

## Testing
- windows bootstrap with GH_TOKEN set -> setup-all completes without manual GitHub prompts
- ./scripts/github-hardening.sh with GH_TOKEN lacking scopes -> fails refresh once and skips with pending notice
