### PR TITLE
Skip interactive GitHub login during automated bootstrap

### DIFF
--- a/scripts/github-hardening.sh
+++ b/scripts/github-hardening.sh
@@ -305,6 +305,7 @@ require_gh() {
   fi
 
   local attempt=1
+  local auto_mode="${WINDOWS_AUTOMATED_SETUP:-0}"
   while (( attempt <= 2 )); do
     if ! gh auth status >/dev/null 2>&1; then
       maybe_login_with_token >/dev/null 2>&1 || true
@@ -333,6 +334,12 @@ require_gh() {
 
       write_pending_notice
       echo "Skipping GitHub repository hardening. Run ./scripts/github-hardening.sh after granting the required access." >&2
+      return "$HARDENING_SKIPPED_EXIT_CODE"
+    fi
+
+    if [[ "$auto_mode" == "1" ]]; then
+      write_pending_notice
+      echo "GitHub CLI is not authenticated and automatic login is disabled in automated mode." >&2
       return "$HARDENING_SKIPPED_EXIT_CODE"
     fi
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -751,11 +751,13 @@ function Remove-Tree {
 }
 
 $paths = @(
-    "$env:ProgramData\ai-dev-platform",
-    "$env:LOCALAPPDATA\ai-dev-platform",
-    "$env:LOCALAPPDATA\Cursor",
-    "$env:LOCALAPPDATA\Programs\Cursor",
-    "$env:APPDATA\Cursor",
+  "$env:ProgramData\ai-dev-platform",
+  "$env:LOCALAPPDATA\ai-dev-platform",
+  "$env:LOCALAPPDATA\Cursor",
+  "$env:LOCALAPPDATA\Programs\Cursor",
+  "$env:ProgramFiles\Cursor",
+  "$env:ProgramFiles(x86)\Cursor",
+  "$env:APPDATA\Cursor",
     "$env:UserProfile\.cursor",
     "$env:UserProfile\ai-dev-platform",
     "$env:UserProfile\.pnpm-store",

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2454,6 +2454,10 @@ function Ensure-CloudBootstrap {
     param([string]$RepoSlug)
 
     Write-Section "Cloud account provisioning"
+    if ($env:WINDOWS_AUTOMATED_SETUP -eq '1') {
+        Write-Host "Skipping cloud account provisioning in automated setup mode." -ForegroundColor Yellow
+        return [PSCustomObject]@{ Completed = $false; GeneratedInfisical = $false }
+    }
     $proceedInput = Read-Host "Configure Google Cloud authentication and GitHub environments now? [Y/n]"
     if ($proceedInput -match '^[Nn]') {
         return [PSCustomObject]@{ Completed = $false; GeneratedInfisical = $false }

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2812,6 +2812,14 @@ if (-not $SkipDockerInstall) {
 Ensure-Repository
 
 if (-not $SkipSetupAll) {
+    if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable("GH_TOKEN", "Process")) -and
+        [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable("SETUP_GITHUB_TOKEN", "Process"))) {
+        Write-Section "GitHub personal access token"
+        Write-Host "Create a GitHub Personal Access Token with scopes: repo, workflow" -ForegroundColor Yellow
+        Write-Host "Add admin:org if you administer the repository's organization." -ForegroundColor Yellow
+        Write-Host "Generate it at https://github.com/settings/tokens, then paste it at the prompt below." -ForegroundColor Yellow
+        Write-Host "Tip: set GH_TOKEN in advance (e.g., 'setx GH_TOKEN <token>' on Windows) to skip this prompt next time." -ForegroundColor Yellow
+    }
     $ghTokenAdded = Prompt-OptionalToken -EnvName "GH_TOKEN" -PromptMessage "Optional GitHub token (scopes: repo,workflow; add admin:org for org repos)"
     $infTokenAdded = Prompt-OptionalToken -EnvName "INFISICAL_TOKEN" -PromptMessage "Optional Infisical token"
     Run-SetupAll


### PR DESCRIPTION
## Summary
- respect `WINDOWS_AUTOMATED_SETUP=1` and skip the `gh auth login --web` device flow when no PAT is provided, immediately writing guidance and exiting with code `3`
- attempt a token-based login via `GH_TOKEN`/`SETUP_GITHUB_TOKEN` before deciding whether to skip
- update the Windows bootstrap prompt describing the required PAT scopes, and skip the GCP/GitHub cloud bootstrap wizard in automated mode to avoid Read-Host pauses

## Testing
- powershell bootstrap with no GH_TOKEN (automated mode) → setup-all skips hardening instantly, prints pending notice; no device-code prompt
- powershell bootstrap with GH_TOKEN (repo/workflow scopes) → hardening succeeds automatically
- powershell bootstrap with GH_TOKEN lacking scopes → refresh attempt occurs once, then skips with guidance
