### PR TITLE
Skip duplicate Cursor installer when elevated

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -1309,12 +1309,21 @@ function Ensure-Cursor {
         Write-CursorLog ("Cursor already installed at {0}" -f $existingPath)
         return
     }
+    $runningElevated = Test-IsAdministrator
     if ($CursorInstallerPath) {
         Write-Host "Using provided Cursor installer path '$CursorInstallerPath'."
         if (Install-CursorFromPath -Path $CursorInstallerPath -ExpectedVersion $null -ExpectedInstallPath $cursorPath) {
             return
         }
         Write-Warning "Custom Cursor installer failed. Falling back to automated options."
+    }
+    if ($runningElevated) {
+        Write-Host "Running in elevated mode; skipping winget and downloading Cursor installer directly." -ForegroundColor Yellow
+        $fallbackInstalled = Install-CursorViaDownload -ExpectedPath $cursorPath
+        if (-not $fallbackInstalled) {
+            Write-Warning "Cursor installation could not be automated. Install Cursor manually from https://cursor.com/download and rerun this script."
+        }
+        return
     }
     try {
         Ensure-Winget


### PR DESCRIPTION
## Summary
- if the bootstrap is running under an elevated PowerShell session, skip the winget installation path and go straight to the direct-download fallback
- avoids launching the Cursor user installer twice (once from winget, once from the fallback)

## Testing
- powershell (Run as Administrator) -NoProfile -ExecutionPolicy RemoteSigned -File .\scripts\windows\setup.ps1
