### PR TITLE
Force GH token login in hardening

### DIFF
--- a/scripts/github-hardening.sh
+++ b/scripts/github-hardening.sh
@@ -153,6 +153,7 @@ maybe_login_with_token() {
     return 1
   fi
   TOKEN_LOGIN_ATTEMPTED=1
+  gh auth logout --hostname github.com >/dev/null 2>&1 || true
   if printf '%s\n' "$token" | gh auth login --hostname github.com --git-protocol https --with-token >/dev/null 2>&1; then
     record_gh_user
     if [[ -n "$GH_USER" ]]; then


### PR DESCRIPTION
## Summary
- when a PAT is supplied via `GH_TOKEN`/`SETUP_GITHUB_TOKEN`, log out the existing gh session and re-authenticate with that token to guarantee the desired scopes/admin rights are used

## Testing
- powershell bootstrap with PAT already configured (confirmed WSL hardening no longer reuses old gh credential)
