### PR TITLE
fix/cursor hardening

### DIFF
--- a/scripts/github-hardening.sh
+++ b/scripts/github-hardening.sh
@@ -310,7 +310,6 @@ require_gh() {
   while (( attempt <= 2 )); do
     maybe_login_with_token >/dev/null 2>&1 || true
     if gh auth status >/dev/null 2>&1; then
-    if gh auth status >/dev/null 2>&1; then
       record_gh_user
       if ensure_gh_scopes && ensure_repo_admin_access; then
         clear_pending_notice

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -393,7 +393,19 @@ function Start-ProcessNonElevated {
     if (-not $shell) {
         throw "Shell.Application COM object unavailable."
     }
-    $arguments = if ($ArgumentList -and $ArgumentList.Count -gt 0) { $ArgumentList -join " " } else { "" }
+    $argumentsArray = @()
+    if ($null -ne $ArgumentList) {
+        if ($ArgumentList -is [System.Collections.IEnumerable] -and -not ($ArgumentList -is [string])) {
+            foreach ($item in $ArgumentList) {
+                if (-not [string]::IsNullOrWhiteSpace($item)) {
+                    $argumentsArray += $item
+                }
+            }
+        } elseif (-not [string]::IsNullOrWhiteSpace($ArgumentList)) {
+            $argumentsArray = @("$ArgumentList")
+        }
+    }
+    $arguments = if ($argumentsArray.Count -gt 0) { $argumentsArray -join " " } else { "" }
     if ([string]::IsNullOrWhiteSpace($WorkingDirectory)) {
         try {
             $WorkingDirectory = Split-Path -Path $FilePath -Parent


### PR DESCRIPTION
## Summary
- stop github hardening from exiting with syntax error by removing duplicated gh auth guard
- normalize Start-ProcessNonElevated arguments so Cursor installer launches only once

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

### Notes for Reviewers
- Manual bootstrap validation still outstanding; change is Windows-only and aims to unblock current failure in screenshot.
