### PR TITLE
fix(cursor): avoid Count lookup when building arguments

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -393,19 +393,13 @@ function Start-ProcessNonElevated {
     if (-not $shell) {
         throw "Shell.Application COM object unavailable."
     }
-    $argumentsArray = @()
+    $argumentItems = @()
     if ($null -ne $ArgumentList) {
-        if ($ArgumentList -is [System.Collections.IEnumerable] -and -not ($ArgumentList -is [string])) {
-            foreach ($item in $ArgumentList) {
-                if (-not [string]::IsNullOrWhiteSpace($item)) {
-                    $argumentsArray += $item
-                }
-            }
-        } elseif (-not [string]::IsNullOrWhiteSpace($ArgumentList)) {
-            $argumentsArray = @("$ArgumentList")
-        }
+        $argumentItems = @(
+            @($ArgumentList) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
     }
-    $arguments = if ($argumentsArray.Count -gt 0) { $argumentsArray -join " " } else { "" }
+    $arguments = if ($argumentItems.Length -gt 0) { $argumentItems -join " " } else { "" }
     if ([string]::IsNullOrWhiteSpace($WorkingDirectory)) {
         try {
             $WorkingDirectory = Split-Path -Path $FilePath -Parent


### PR DESCRIPTION
## Summary
- build the ShellExecute argument string without calling `.Count`, preventing the PowerShell error that forced a second elevated installer window

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

### Notes for Reviewers
- Windows-only; unable to run bootstrap in devcontainer but the change is limited to argument normalization before COM ShellExecute.
