### PR TITLE
fix(cursor): normalize installer args via list

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -394,20 +394,24 @@ function Start-ProcessNonElevated {
         throw "Shell.Application COM object unavailable."
     }
 
-    $arguments = ""
+    $argumentBuffer = New-Object System.Collections.Generic.List[string]
     if ($null -ne $ArgumentList) {
         if ($ArgumentList -is [System.Collections.IEnumerable] -and -not ($ArgumentList -is [string])) {
-            $arguments = ($ArgumentList | ForEach-Object {
-                if ($_ -is [string]) {
-                    $_
-                } elseif ($null -ne $_) {
-                    $_.ToString()
+            foreach ($item in $ArgumentList) {
+                if ($null -eq $item) { continue }
+                $text = [string]$item
+                if (-not [string]::IsNullOrWhiteSpace($text)) {
+                    $null = $argumentBuffer.Add($text)
                 }
-            } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join " "
-        } elseif (-not [string]::IsNullOrWhiteSpace([string]$ArgumentList)) {
-            $arguments = [string]$ArgumentList
+            }
+        } else {
+            $text = [string]$ArgumentList
+            if (-not [string]::IsNullOrWhiteSpace($text)) {
+                $null = $argumentBuffer.Add($text)
+            }
         }
     }
+    $arguments = if ($argumentBuffer.Count -gt 0) { [string]::Join(" ", $argumentBuffer) } else { "" }
 
     if ([string]::IsNullOrWhiteSpace($WorkingDirectory)) {
         try {


### PR DESCRIPTION
## Summary
- avoid ShellExecute argument errors by copying enumerables into a plain `List[string]` before joining; this prevents PowerShell from trying to access `.Count` on arbitrary COM iterable types and eliminates the fallback elevated installer

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

### Notes for Reviewers
- Windows-only bootstrap flow; change simply buffers args before launching ShellExecute.
