### PR TITLE
fix(cursor): poll installer exit without Count

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -529,14 +529,18 @@ function Wait-ForProcessExitByPath {
     $escaped = $fullPath.Replace("\", "\\")
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     while ([DateTime]::UtcNow -lt $deadline) {
-        $processes = @()
+        $processesList = New-Object System.Collections.Generic.List[object]
         try {
-            $processes = @(Get-CimInstance Win32_Process -Filter "ExecutablePath = '$escaped'")
+            $rawProcesses = Get-CimInstance Win32_Process -Filter "ExecutablePath = '$escaped'"
         } catch {
-            $processes = @()
+            $rawProcesses = @()
         }
-        $processes = $processes | Where-Object { $_ }
-        if (-not $processes -or $processes.Count -eq 0) {
+        foreach ($proc in @($rawProcesses)) {
+            if ($null -ne $proc) {
+                $null = $processesList.Add($proc)
+            }
+        }
+        if ($processesList.Count -eq 0) {
             return $true
         }
         Start-Sleep -Seconds 3


### PR DESCRIPTION
## Summary
- rewrite `Wait-ForProcessExitByPath` to copy CIM query results into a managed list before checking for remaining processes, so we never access `.Count` on `System.__ComObject`
- prevents the `PropertyNotFoundException` that forced the installer fallback and spawned a second elevated Cursor setup window

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

### Notes for Reviewers
- Windows-only change; validated logically by eliminating `.Count` usage on CIM objects.
