### PR TITLE
fix/setup sandbox repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ $env:AI_DEV_PLATFORM_SANDBOX_REPO = 'your-user/ai-dev-platform-sandbox'
 powershell -NoProfile -ExecutionPolicy RemoteSigned -File .\sync-sandbox.ps1 -ForceClean
 ```
 
+> The same `AI_DEV_PLATFORM_SANDBOX_REPO` environment variable is honored by `scripts/windows/setup.ps1`, so once it is set the Windows bootstrap automatically clones and hardens **your** fork instead of the upstream repo.
+
 Need a fresh fork for testing? Run this one-liner (requires a PAT with `delete_repo` scope) and it will delete the old fork, recreate it privately, reclone it, and sync it—all with a single command:
 
 ```powershell

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -34,6 +34,11 @@ if ($CursorInstallerPath) {
     }
 }
 
+if (-not $PSBoundParameters.ContainsKey('RepoSlug') -and -not [string]::IsNullOrWhiteSpace($env:AI_DEV_PLATFORM_SANDBOX_REPO)) {
+    Write-Host ("Using sandbox repository slug '{0}' from AI_DEV_PLATFORM_SANDBOX_REPO." -f $env:AI_DEV_PLATFORM_SANDBOX_REPO) -ForegroundColor Cyan
+    $RepoSlug = $env:AI_DEV_PLATFORM_SANDBOX_REPO
+}
+
 if ($DistroName.StartsWith("[") -or $DistroName.StartsWith("-")) {
     Write-Warning "Received DistroName '$DistroName'; resetting to 'Ubuntu'. Use -DistroName if you need a custom image."
     $DistroName = "Ubuntu"

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -37,6 +37,7 @@ if ($CursorInstallerPath) {
 if (-not $PSBoundParameters.ContainsKey('RepoSlug') -and -not [string]::IsNullOrWhiteSpace($env:AI_DEV_PLATFORM_SANDBOX_REPO)) {
     Write-Host ("Using sandbox repository slug '{0}' from AI_DEV_PLATFORM_SANDBOX_REPO." -f $env:AI_DEV_PLATFORM_SANDBOX_REPO) -ForegroundColor Cyan
     $RepoSlug = $env:AI_DEV_PLATFORM_SANDBOX_REPO
+    Ensure-WslEnvPassthrough -VariableName 'AI_DEV_PLATFORM_SANDBOX_REPO'
 }
 
 if ($DistroName.StartsWith("[") -or $DistroName.StartsWith("-")) {
@@ -2539,10 +2540,16 @@ user_home=`$(getent passwd `$(whoami) | cut -d: -f6)
 if [ -n "`$user_home" ]; then
   export HOME="`$user_home"
 fi
-if [ ! -d "`$HOME/ai-dev-platform/.git" ]; then
-  git clone https://github.com/$RepoSlug.git "`$HOME/ai-dev-platform"
+repo_url="https://github.com/$RepoSlug.git"
+repo_dir="`$HOME/ai-dev-platform"
+if [ ! -d "`$repo_dir/.git" ]; then
+  git clone "`$repo_url" "`$repo_dir"
 fi
-cd "`$HOME/ai-dev-platform"
+cd "`$repo_dir"
+current_origin="$(git remote get-url origin 2>/dev/null)"
+if [ "`$current_origin" != "`$repo_url" ]; then
+  git remote set-url origin "`$repo_url"
+fi
 git fetch origin
 git checkout $Branch
 git pull --ff-only origin $Branch || true


### PR DESCRIPTION
## Summary
- allow `AI_DEV_PLATFORM_SANDBOX_REPO` to drive `scripts/windows/setup.ps1` so the bootstrap clones/hardens your fork automatically
- ensure existing WSL clones retarget their `origin` remote to match the sandbox slug, so PATs are applied where you have admin rights

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

### Notes for Reviewers
- Fixes the repo hardening loop by making the bootstrap clone the user’s fork when the env var is set (and syncing README guidance).
