### PR TITLE
fix(setup): define Ensure-WslEnvPassthrough before use

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -56,6 +56,21 @@ if ([string]::IsNullOrWhiteSpace($RepoSlug) -or (-not $RepoSlug.Contains("/"))) 
 $env:AI_DEV_PLATFORM_SANDBOX_REPO = $RepoSlug
 Ensure-WslEnvPassthrough -VariableName 'AI_DEV_PLATFORM_SANDBOX_REPO'
 
+function Ensure-WslEnvPassthrough {
+    param([string]$VariableName)
+    if ([string]::IsNullOrWhiteSpace($VariableName)) { return }
+    $current = [Environment]::GetEnvironmentVariable('WSLENV','Process')
+    $parts = @()
+    if (-not [string]::IsNullOrWhiteSpace($current)) {
+        $parts = $current -split ';' | Where-Object { $_ }
+    }
+    $entry = "$VariableName/p"
+    if ($parts -notcontains $entry) {
+        $parts += $entry
+        [Environment]::SetEnvironmentVariable('WSLENV', ($parts -join ';'), 'Process')
+    }
+}
+
 if ($DistroName.StartsWith("[") -or $DistroName.StartsWith("-")) {
     Write-Warning "Received DistroName '$DistroName'; resetting to 'Ubuntu'. Use -DistroName if you need a custom image."
     $DistroName = "Ubuntu"
@@ -502,21 +517,6 @@ function Wait-ForWingetCursorInstaller {
     return [pscustomobject]@{
         Completed = $false
         InstallerActive = ($stillRunning -and $stillRunning.Count -gt 0)
-    }
-}
-
-function Ensure-WslEnvPassthrough {
-    param([string]$VariableName)
-    if ([string]::IsNullOrWhiteSpace($VariableName)) { return }
-    $current = [Environment]::GetEnvironmentVariable('WSLENV','Process')
-    $parts = @()
-    if (-not [string]::IsNullOrWhiteSpace($current)) {
-        $parts = $current -split ';' | Where-Object { $_ }
-    }
-    $entry = "$VariableName/p"
-    if ($parts -notcontains $entry) {
-        $parts += $entry
-        [Environment]::SetEnvironmentVariable('WSLENV', ($parts -join ';'), 'Process')
     }
 }
 


### PR DESCRIPTION
## Summary
- move `Ensure-WslEnvPassthrough` above its first use in `scripts/windows/setup.ps1` and remove the duplicate definition later in the file
- fixes the "term not recognized" error when the bootstrap tries to pass `AI_DEV_PLATFORM_SANDBOX_REPO` into WSL on a fresh machine

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

### Notes for Reviewers
- docs-only wiring fix; ensures the seamless setup flow works on clean machines.
