### PR TITLE
fix(setup): move Ensure-WslEnvPassthrough before usage

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -17,6 +17,21 @@ $script:CursorInstallerContextReady = $false
 $script:CursorInstallerCacheDir = $null
 $script:CursorInstallerLogFile = $null
 $script:CursorInstallerLogAdvertised = $false
+
+function Ensure-WslEnvPassthrough {
+    param([string]$VariableName)
+    if ([string]::IsNullOrWhiteSpace($VariableName)) { return }
+    $current = [Environment]::GetEnvironmentVariable('WSLENV','Process')
+    $parts = @()
+    if (-not [string]::IsNullOrWhiteSpace($current)) {
+        $parts = $current -split ';' | Where-Object { $_ }
+    }
+    $entry = "$VariableName/p"
+    if ($parts -notcontains $entry) {
+        $parts += $entry
+        [Environment]::SetEnvironmentVariable('WSLENV', ($parts -join ';'), 'Process')
+    }
+}
 if (-not $DockerInstallerPath -and $env:DOCKER_DESKTOP_INSTALLER) {
     $DockerInstallerPath = $env:DOCKER_DESKTOP_INSTALLER
 }
@@ -55,21 +70,6 @@ if ([string]::IsNullOrWhiteSpace($RepoSlug) -or (-not $RepoSlug.Contains("/"))) 
 
 $env:AI_DEV_PLATFORM_SANDBOX_REPO = $RepoSlug
 Ensure-WslEnvPassthrough -VariableName 'AI_DEV_PLATFORM_SANDBOX_REPO'
-
-function Ensure-WslEnvPassthrough {
-    param([string]$VariableName)
-    if ([string]::IsNullOrWhiteSpace($VariableName)) { return }
-    $current = [Environment]::GetEnvironmentVariable('WSLENV','Process')
-    $parts = @()
-    if (-not [string]::IsNullOrWhiteSpace($current)) {
-        $parts = $current -split ';' | Where-Object { $_ }
-    }
-    $entry = "$VariableName/p"
-    if ($parts -notcontains $entry) {
-        $parts += $entry
-        [Environment]::SetEnvironmentVariable('WSLENV', ($parts -join ';'), 'Process')
-    }
-}
 
 if ($DistroName.StartsWith("[") -or $DistroName.StartsWith("-")) {
     Write-Warning "Received DistroName '$DistroName'; resetting to 'Ubuntu'. Use -DistroName if you need a custom image."


### PR DESCRIPTION
## Summary
- define `Ensure-WslEnvPassthrough` before its first use so the bootstrap can set/passthrough `AI_DEV_PLATFORM_SANDBOX_REPO` on fresh machines
- removes the duplicate definition later in the file (no behavior change besides eliminating the "function not recognized" error)

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

### Notes for Reviewers
- Fixes the regression that broke the bootstrap as soon as it tried to pass env vars into WSL.
