### PR TITLE
fix(setup): escape slug when emitting WSL clone script

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2552,6 +2552,7 @@ function Ensure-DockerDesktop {
 function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
     $escapedSlug = $RepoSlug.Replace('"','\"')
+    $escapedSlug = $escapedSlug.Replace('$', '`\$')
     $cloneScript = @"
 repo_slug="`$\{AI_DEV_PLATFORM_SANDBOX_REPO:-$escapedSlug}"
 if [ -z "`$repo_slug" ]; then


### PR DESCRIPTION
## Summary
- escape `$RepoSlug` when emitting the WSL clone script so the fallback expression `${AI_DEV_PLATFORM_SANDBOX_REPO:-...}` survives PowerShell interpolation
- fixes "syntax error: unexpected end of file" when the slug contains `$` characters

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).
