### PR TITLE
fix(setup): embed repo slug via placeholder in WSL script

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2551,10 +2551,8 @@ function Ensure-DockerDesktop {
 
 function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
-    $escapedSlug = $RepoSlug.Replace('"','\"')
-    $escapedSlug = $escapedSlug.Replace('$', '`\$')
-    $cloneScript = @"
-repo_slug="`$\{AI_DEV_PLATFORM_SANDBOX_REPO:-$escapedSlug}"
+    $cloneScript = @'
+repo_slug="${AI_DEV_PLATFORM_SANDBOX_REPO:-__REPO_SLUG_PLACEHOLDER__}"
 if [ -z "`$repo_slug" ]; then
   echo "Repository slug is empty inside WSL. Set AI_DEV_PLATFORM_SANDBOX_REPO=owner/repo before rerunning." >&2
   exit 129
@@ -2576,7 +2574,8 @@ fi
 git fetch origin
 git checkout $Branch
 git pull --ff-only origin $Branch || true
-"@
+'@
+    $cloneScript = $cloneScript.Replace('__REPO_SLUG_PLACEHOLDER__', $RepoSlug)
     $result = Invoke-Wsl -Command $cloneScript
     if ($result.ExitCode -ne 0) {
         throw "Failed to clone or update repository inside WSL (exit $($result.ExitCode))."


### PR DESCRIPTION
## Summary
- render the WSL clone script via a literal here-string with a placeholder, then substitute the actual repo slug afterwards; fixes the `slug: -c: line 4` syntax error when the slug contains `$`

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).
