### PR TITLE
fix(setup): generate WSL clone script via placeholders

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2553,29 +2553,29 @@ function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
     $cloneScript = @'
 repo_slug="${AI_DEV_PLATFORM_SANDBOX_REPO:-__REPO_SLUG_PLACEHOLDER__}"
-if [ -z "`$repo_slug" ]; then
+if [ -z "$repo_slug" ]; then
   echo "Repository slug is empty inside WSL. Set AI_DEV_PLATFORM_SANDBOX_REPO=owner/repo before rerunning." >&2
   exit 129
 fi
-user_home=`$(getent passwd `$(whoami) | cut -d: -f6)
-if [ -n "`$user_home" ]; then
-  export HOME="`$user_home"
+user_home=$(getent passwd $(whoami) | cut -d: -f6)
+if [ -n "$user_home" ]; then
+  export HOME="$user_home"
 fi
-repo_url="https://github.com/`$repo_slug.git"
-repo_dir="`$HOME/ai-dev-platform"
-if [ ! -d "`$repo_dir/.git" ]; then
-  git clone "`$repo_url" "`$repo_dir" || exit \$?
+repo_url="https://github.com/$repo_slug.git"
+repo_dir="$HOME/ai-dev-platform"
+if [ ! -d "$repo_dir/.git" ]; then
+  git clone "$repo_url" "$repo_dir" || exit $?
 fi
-cd "`$repo_dir"
+cd "$repo_dir"
 current_origin="$(git remote get-url origin 2>/dev/null)"
-if [ "`$current_origin" != "`$repo_url" ]; then
-  git remote set-url origin "`$repo_url"
+if [ "$current_origin" != "$repo_url" ]; then
+  git remote set-url origin "$repo_url"
 fi
 git fetch origin
-git checkout $Branch
-git pull --ff-only origin $Branch || true
+git checkout "__BRANCH_PLACEHOLDER__"
+git pull --ff-only origin "__BRANCH_PLACEHOLDER__" || true
 '@
-    $cloneScript = $cloneScript.Replace('__REPO_SLUG_PLACEHOLDER__', $RepoSlug)
+    $cloneScript = $cloneScript.Replace('__REPO_SLUG_PLACEHOLDER__', $RepoSlug).Replace('__BRANCH_PLACEHOLDER__', $Branch)
     $result = Invoke-Wsl -Command $cloneScript
     if ($result.ExitCode -ne 0) {
         throw "Failed to clone or update repository inside WSL (exit $($result.ExitCode))."


### PR DESCRIPTION
## Summary
- build the WSL clone/update script using a literal here-string with both repo-slug and branch placeholders, then substitute the real values afterwards
- removes the need for odd escape sequences and fixes the `/bin/bash: -c: line N: unexpected EOF` errors that occurred when the slug contained `$` or when CRLF mangled nested `$(...)`

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).
