### PR TITLE
fix(setup): render WSL script via placeholders

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -2551,34 +2551,32 @@ function Ensure-DockerDesktop {
 
 function Ensure-Repository {
     Write-Section "Cloning repository inside WSL"
-    $repoSlugEscaped = $RepoSlug.Replace('"','\"')
-    $branchEscaped = $Branch.Replace('"','\"')
     $scriptLines = @(
-        "set -e",
-        "repo_slug=\"`${AI_DEV_PLATFORM_SANDBOX_REPO:-$repoSlugEscaped}\"",
-        "if [ -z \"\$repo_slug\" ]; then",
-        "  echo \"Repository slug is empty inside WSL. Set AI_DEV_PLATFORM_SANDBOX_REPO=owner/repo before rerunning.\" >&2",
-        "  exit 129",
-        "fi",
-        "user_home=\$(getent passwd \$(whoami) | cut -d: -f6)",
-        "if [ -n \"\$user_home\" ]; then",
-        "  export HOME=\"\$user_home\"",
-        "fi",
-        "repo_url=\"https://github.com/\$repo_slug.git\"",
-        "repo_dir=\"\$HOME/ai-dev-platform\"",
-        "if [ ! -d \"\$repo_dir/.git\" ]; then",
-        "  git clone \"\$repo_url\" \"\$repo_dir\" || exit \$?",
-        "fi",
-        "cd \"\$repo_dir\"",
-        "current_origin=\"\$(git remote get-url origin 2>/dev/null)\"",
-        "if [ \"\$current_origin\" != \"\$repo_url\" ]; then",
-        "  git remote set-url origin \"\$repo_url\"",
-        "fi",
-        "git fetch origin",
-        "git checkout \"$branchEscaped\"",
-        "git pull --ff-only origin \"$branchEscaped\" || true"
+        'set -e',
+        'repo_slug="${AI_DEV_PLATFORM_SANDBOX_REPO:-__REPO_SLUG_PLACEHOLDER__}"',
+        'if [ -z "$repo_slug" ]; then',
+        '  echo "Repository slug is empty inside WSL. Set AI_DEV_PLATFORM_SANDBOX_REPO=owner/repo before rerunning." >&2',
+        '  exit 129',
+        'fi',
+        'user_home=$(getent passwd $(whoami) | cut -d: -f6)',
+        'if [ -n "$user_home" ]; then',
+        '  export HOME="$user_home"',
+        'fi',
+        'repo_url="https://github.com/$repo_slug.git"',
+        'repo_dir="$HOME/ai-dev-platform"',
+        'if [ ! -d "$repo_dir/.git" ]; then',
+        '  git clone "$repo_url" "$repo_dir" || exit $?',
+        'fi',
+        'cd "$repo_dir"',
+        'current_origin="$(git remote get-url origin 2>/dev/null)"',
+        'if [ "$current_origin" != "$repo_url" ]; then',
+        '  git remote set-url origin "$repo_url"',
+        'fi',
+        'git fetch origin',
+        'git checkout "__BRANCH_PLACEHOLDER__"',
+        'git pull --ff-only origin "__BRANCH_PLACEHOLDER__" || true'
     )
-    $innerScript = ($scriptLines -join "`n")
+    $innerScript = ($scriptLines -join "`n").Replace('__REPO_SLUG_PLACEHOLDER__', $RepoSlug).Replace('__BRANCH_PLACEHOLDER__', $Branch)
     $command = @"
 cat <<'EOF' >/tmp/ai-dev-clone.sh
 $innerScript


### PR DESCRIPTION
## Summary
- build the WSL clone/update Bash script from literal single-quoted lines with repo/branch placeholders, then replace them in PowerShell before writing the heredoc
- removes every remaining `$repo_slug` evaluation bug so `scripts/windows/setup.ps1` can clone any sandbox fork without syntax errors

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).
