### PR TITLE
fix(setup): run wsl gh auth via temp script

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -3170,9 +3170,13 @@ exit 0
     if ($envPrefix) {
         $commands += $envPrefix
     }
-    $commands += "base64 -d <<'__WSLGH__' | bash"
-    $commands += $scriptBase64
-    $commands += "__WSLGH__"
+    $commands += 'tmp_script=$(mktemp /tmp/ai-dev-gh-auth.XXXXXX.sh)'
+    $commands += "printf '%s' '$scriptBase64' | base64 -d > \"\$tmp_script\""
+    $commands += 'chmod +x "$tmp_script"'
+    $commands += 'bash "$tmp_script"'
+    $commands += 'status=$?'
+    $commands += 'rm -f "$tmp_script"'
+    $commands += 'exit $status'
     $command = ($commands -join '; ')
     $result = Invoke-Wsl -Command $command
     if ($result.ExitCode -ne 0) {


### PR DESCRIPTION
## Summary

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

- Fix the WSL GitHub auth helper to write the generated Bash to a temp file, execute it, and clean it up so PowerShell no longer mangles the heredoc and causes `exit 127`.
- Keeps the scope/admin validation intact while making the Windows bootstrap fully unattended again.

### Notes for Reviewers

- PowerShell change verified via lint-staged (prettier). Please rerun the bootstrap on Windows to exercise the new helper end-to-end.
