### PR TITLE
fix(setup): escape tmp script command

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -3171,7 +3171,7 @@ exit 0
         $commands += $envPrefix
     }
     $commands += 'tmp_script=$(mktemp /tmp/ai-dev-gh-auth.XXXXXX.sh)'
-    $commands += "printf '%s' '$scriptBase64' | base64 -d > \"\$tmp_script\""
+    $commands += ('printf ''%s'' ''{0}'' | base64 -d > $tmp_script' -f $scriptBase64)
     $commands += 'chmod +x "$tmp_script"'
     $commands += 'bash "$tmp_script"'
     $commands += 'status=$?'


### PR DESCRIPTION
## Summary

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

- Fix the WSL GitHub auth helper to emit the base64 payload using PowerShell formatting with single quotes, so `$tmp_script` stays literal and PowerShell no longer throws "Unexpected token" errors.

### Notes for Reviewers

- Change validated via lint-staged (prettier). Please re-run the Windows bootstrap to confirm the prompt no longer errors.
