### PR TITLE
fix(setup): write wsl gh auth script to literal path

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -3165,17 +3165,17 @@ exit 0
     $script = $scriptTemplate.Replace('__REQUIRED_SCOPES__', $scopeLiteral).Replace('__REPO_SLUG__', $repoLiteral)
     $scriptBytes = [System.Text.Encoding]::UTF8.GetBytes($script)
     $scriptBase64 = [Convert]::ToBase64String($scriptBytes)
+    $tmpScriptPath = "/tmp/ai-dev-gh-auth-$([Guid]::NewGuid().ToString('N')).sh"
     $commands = @()
     $envPrefix = Get-WslEnvPrefix
     if ($envPrefix) {
         $commands += $envPrefix
     }
-    $commands += 'tmp_script=$(mktemp /tmp/ai-dev-gh-auth.XXXXXX.sh)'
-    $commands += ('printf ''%s'' ''{0}'' | base64 -d > $tmp_script' -f $scriptBase64)
-    $commands += 'chmod +x "$tmp_script"'
-    $commands += 'bash "$tmp_script"'
+    $commands += ("printf '%s' '{0}' | base64 -d > '{1}'" -f $scriptBase64, $tmpScriptPath)
+    $commands += ("chmod +x '{0}'" -f $tmpScriptPath)
+    $commands += ("bash '{0}'" -f $tmpScriptPath)
     $commands += 'status=$?'
-    $commands += 'rm -f "$tmp_script"'
+    $commands += ("rm -f '{0}'" -f $tmpScriptPath)
     $commands += 'exit $status'
     $command = ($commands -join '; ')
     $result = Invoke-Wsl -Command $command


### PR DESCRIPTION
## Summary

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

- Stop relying on `$tmp_script` inside the WSL command string; PowerShell was stripping it, so `printf … > $tmp_script` had no target and the bootstrap kept failing.
- Generate a literal `/tmp/ai-dev-gh-auth-<guid>.sh` path, emit/execute/clean it directly, so the decoded GitHub auth helper always runs.

### Notes for Reviewers

- Syntax validated via lint-staged. Please rerun the Windows bootstrap to confirm repo hardening now succeeds.
