### PR TITLE
fix(setup): run wsl auth script with bash

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -3114,6 +3114,7 @@ function Ensure-WslGithubAuthentication {
     $repoLiteral = $RepoSlug
 
     $scriptTemplate = @'
+#!/usr/bin/env bash
 set -euo pipefail
 if ! command -v gh >/dev/null 2>&1; then
   echo "GitHub CLI is not installed inside WSL." >&2


### PR DESCRIPTION
## Summary

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

- Add `#!/usr/bin/env bash` to the generated WSL GitHub-auth helper so `set -euo pipefail` no longer runs under `/bin/sh` when executed directly.

### Notes for Reviewers

- Please rerun the Windows bootstrap to confirm the helper no longer fails with `set: pipefail: invalid option name`.
