### PR TITLE
fix(setup): ensure wsl auth script has shebang

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -3161,7 +3161,7 @@ if ! gh api "repos/__REPO_SLUG__" --jq '.permissions.admin' >/dev/null 2>&1; the
   exit 4
 fi
 exit 0
-'@
+'@.TrimStart()
 
     $script = $scriptTemplate.Replace('__REQUIRED_SCOPES__', $scopeLiteral).Replace('__REPO_SLUG__', $repoLiteral)
     $scriptBytes = [System.Text.Encoding]::UTF8.GetBytes($script)


### PR DESCRIPTION
## Summary

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

- Trim the generated WSL GitHub auth helper so `#!/usr/bin/env bash` is the first byte; previously a leading newline caused `/bin/sh` to interpret the script and reject `set -euo pipefail`.

### Notes for Reviewers

- Please rerun the Windows bootstrap to confirm GH auth succeeds.
