### PR TITLE
fix(setup): force bash for wsl auth helper

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -3174,7 +3174,7 @@ exit 0
     }
     $commands += ("printf '%s' '{0}' | base64 -d > '{1}'" -f $scriptBase64, $tmpScriptPath)
     $commands += ("chmod +x '{0}'" -f $tmpScriptPath)
-    $commands += ("bash '{0}'" -f $tmpScriptPath)
+    $commands += ("/bin/bash '{0}'" -f $tmpScriptPath)
     $commands += 'status=$?'
     $commands += ("rm -f '{0}'" -f $tmpScriptPath)
     $commands += 'exit $status'


### PR DESCRIPTION
## Summary

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

- Execute the decoded WSL GitHub auth script with `/bin/bash` explicitly; WSL's default `/bin/sh` was still handling the script and rejecting `set -euo pipefail`.

### Notes for Reviewers

- Please rerun the Windows bootstrap to confirm repo hardening now succeeds.
