### PR TITLE
fix(setup): ensure gh auth helper runs under bash

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -3113,7 +3113,7 @@ function Ensure-WslGithubAuthentication {
     $scopeLiteral = $lowerScopes -join ' '
     $repoLiteral = $RepoSlug
 
-    $scriptTemplate = @'
+    $scriptTemplate = (@'
 #!/usr/bin/env bash
 set -euo pipefail
 if ! command -v gh >/dev/null 2>&1; then
@@ -3161,7 +3161,7 @@ if ! gh api "repos/__REPO_SLUG__" --jq '.permissions.admin' >/dev/null 2>&1; the
   exit 4
 fi
 exit 0
-'@.TrimStart()
+'@).TrimStart()
 
     $script = $scriptTemplate.Replace('__REQUIRED_SCOPES__', $scopeLiteral).Replace('__REPO_SLUG__', $repoLiteral)
     $scriptBytes = [System.Text.Encoding]::UTF8.GetBytes($script)


### PR DESCRIPTION
## Summary

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

- Wrap the GitHub auth helper here-string in `(...).TrimStart()` and force `/bin/bash` when executing it so `set -euo pipefail` always runs under bash.

### Notes for Reviewers

- Please rerun the Windows bootstrap to verify the repo-hardening step now proceeds.
