### PR TITLE
feat(sync): auto-close processes locking repo dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ powershell -NoProfile -ExecutionPolicy RemoteSigned -File .\sync-sandbox.ps1 -Fo
 
 > **GitHub token tip:** The Windows bootstrap now validates `GH_TOKEN` before running any WSL setup. Paste a classic PAT that includes `repo` and `workflow` scopes for personal repositories; if the repo lives in an organization you administer, `admin:org` and administrator rights are required too. The helper will keep prompting until the token passes those checks, then automatically logs `gh` inside WSL with that token so the later GitHub hardening step never fails mid-run.
 
+> **No more “folder in use” restarts:** `sync-sandbox.ps1` now detects any shells, IDEs, or background tools that still have `C:\dev\ai-dev-platform` open. It shows you the offending processes and, with your approval, terminates them automatically so the directory can be cleaned without rebooting Windows. If you prefer to close them manually, answer `n` at the prompt and rerun the command once the list is clear.
+
 Need a fresh fork for testing? Run this one-liner (requires a PAT with `delete_repo` scope) and it will delete the old fork, recreate it privately, reclone it, and sync it—all with a single command:
 
 ```powershell


### PR DESCRIPTION
## Summary

- [ ] Tests were written or updated first (TDD) and demonstrate the change.
- [ ] ./scripts/test-suite.sh was run locally and passed.
- [ ] ./scripts/update-editor-extensions.sh + ./scripts/verify-editor-extensions.sh --strict were run if editor tooling changed.
- [ ] ./scripts/git-sync-check.sh output was reviewed (automatically posted by scripts/push-pr.sh).

- `sync-sandbox.ps1` now detects any shells/IDEs/tools that still have `C:\dev\ai-dev-platform` open, shows the offending processes, and (with confirmation) closes them automatically so the repo can be reset without rebooting Windows.
- README documents the auto-close behavior so folks know the helper will release locks instead of forcing a restart.

### Notes for Reviewers

- No functional changes outside the sync helper + docs.
