### PR TITLE
fix(sync): quote path in lock warning

### DIFF
--- a/sync-sandbox.ps1
+++ b/sync-sandbox.ps1
@@ -59,7 +59,7 @@ function Ensure-RepoDirectoryIsFree {
             return
         }
 
-        Write-Host ""; Write-Host "The following processes are using $Path:" -ForegroundColor Yellow
+        Write-Host ""; Write-Host "The following processes are using ${Path}:" -ForegroundColor Yellow
         $lockers | Select-Object Name, Id, CommandLine | Format-Table -AutoSize | Out-String | Write-Host
 
         $response = Read-Host "Close these processes automatically? [Y/n]"


### PR DESCRIPTION
Wraps  in  inside the process-lock warning so PowerShell doesn’t misparse drive letters (`C:`), eliminating the parser error when running `sync-sandbox.ps1`.